### PR TITLE
chore(ci): add changeset

### DIFF
--- a/.changeset/strong-horses-train.md
+++ b/.changeset/strong-horses-train.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+re-ordering of core index.ts

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,5 +8,5 @@ export * from './components/grid';
 export * from './components/flex';
 export * from './components/avatar';
 export * from './components/text-input';
-export * from './components/theme-provider';
 export * from './components/text';
+export * from './components/theme-provider';


### PR DESCRIPTION
### Summary:
This PR includes multiple improvements across the Vapor UI monorepo, focusing on React version compatibility, build optimization, and release process updates.

### Changes:

#### 🔄 **React Version Downgrade**
- **Root & Core Package**: Downgraded React and React DOM from v19 to v18.3.1
- **Type Definitions**: Updated `@types/react` and `@types/react-dom` to v18.0.0
- **Dependencies**: Updated all Radix UI components and related packages to be compatible with React 18
- **Lock File**: Comprehensive update of `pnpm-lock.yaml` to reflect all dependency changes

#### 🧹 **Clean Script Enhancement**
- **Performance**: Improved clean script to use `pnpm -r --parallel exec rimraf` for efficient parallel execution
- **Coverage**: Now cleans `node_modules`, `.turbo`, `dist`, `.next`, and `.source` directories across all workspaces
- **Reliability**: More robust cleaning process for the monorepo structure

#### 📦 **Core Package Updates**
- **Export Order**: Reordered exports in `packages/core/src/index.ts` for better organization
- **Dependencies**: Updated core package dependencies to match React 18 requirements

#### �� **Release Workflow Update**
- **Branch Trigger**: Changed release workflow trigger from `main` to `release-test` branch
- **Testing**: Enables safer release testing process before main branch deployment

#### �� **Documentation**
- **Changeset**: Added changeset entry for core package reordering

### Technical Details:
- **React**: `^19.1.0` → `^18.0.0` (18.3.1)
- **React DOM**: `^19.1.0` → `^18.0.0` (18.3.1)
- **@types/react**: `^19.1.2` → `^18.0.0` (18.3.23)
- **@types/react-dom**: `^19.1.3` → `^18.0.0` (18.3.7)
- **Clean Script**: Enhanced for parallel execution across monorepo workspaces
- **Release Workflow**: Updated to use `release-test` branch for safer deployments

This change ensures better compatibility with existing React 18 ecosystems while improving build performance and release safety.