### PR TITLE
fix(build): Resolve build warnings and update Node.js version requirement

### DIFF
--- a/CONTRIBUTING-ko_kr.md
+++ b/CONTRIBUTING-ko_kr.md
@@ -20,7 +20,7 @@
 저희 프로젝트는 다음의 개발 환경을 사용합니다:
 
 - **Package Manager**: `pnpm` v10+
-- **Node.js**: v18+
+- **Node.js**: v20+
 - **Linting & Formatting**: ESLint, Prettier
 
 먼저 프로젝트를 Fork 및 Clone 한 후, 아래 명령어로 의존성을 설치하고 개발 서버를 실행하세요.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ There are many ways to contribute to Vapor UI:
 Our project uses the following development environment:
 
 - **Package Manager**: `pnpm` v10+
-- **Node.js**: v18+
+- **Node.js**: v20+
 - **Linting & Formatting**: ESLint, Prettier
 
 First, fork and clone the project, then install the dependencies and run the development server with the commands below:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "vite": "^6.1.0"
     },
     "engines": {
-        "node": "18.x"
+        "node": ">=20.x"
     },
     "packageManager": "pnpm@10.5.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,8 @@
         "dist"
     ],
     "sideEffects": [
-        "**/*.css"
+        "**/*.css",
+        "**/*.css.ts"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Overview

1. add `sideEffects`'s `**/*.css.ts`
2. update `engines` node: `"18.x"` -> `">=20.x"`

# The Problem

### 1. Missing `vanilla-extract` styles due to `sideEffects` configuration

During the build process, the following warning was repeatedly displayed:

```shell
▲ [WARNING] Ignoring this import because "src/styles/global.css.ts" was marked as having no side effects [ignored-bare-import]

    src/styles/contract.css.ts:3:11:
      3 │     import './global.css';
```

**Cause**: `vanilla-extract` injects styles simply by importing `.css.ts` files. However, the `**/*.css.ts` pattern was missing from the `sideEffects` field in `@vapor-ui/core`'s `package.json`. This caused the build tool (`tsup`) to treat these imports as unnecessary code and remove them via tree-shaking.

**Impact**: This created a critical potential bug where essential CSS, such as global styles, could be omitted from the final build output.

### 2. Node.js Version Mismatch Warning

The following engine version warning appeared at the top of the build log:

```shell
 WARN  Unsupported engine: wanted: {"node":"18.x"} (current: {"node":"v20.15.0","pnpm":"10.5.0"})
```

**Cause:** This was caused by a mismatch between the recommended Node.js version in the root `package.json` (`18.x`) and the current development environment's version (`20.x`). This could lead to unexpected issues due to differing developer environments.


# Changes
### 1. Added `sideEffects` Configuration

Added the `**/*.css.ts` pattern to the `package.json` of the `@vapor-ui/core` package. This explicitly marks `vanilla-extract` style files as having side effects, ensuring they are processed correctly during the build.

`packages/core/package.json`

```diff
     "files": [
         "dist"
     ],
     "sideEffects": [
-        "**/*.css"
+        "**/*.css",
+        "**/*.css.ts"
     ],
     "repository": {
         "type": "git",
```

### 2. Updated engines Requirement

Updated the required Node.js version in the root package.json from 18.x to >=20.x to match the current development environment and resolve the warning.

`package.json (root)`

```diff
-    "engines": {
-        "node": "18.x"
-    },
+    "engines": {
+        "node": ">=20.x"
+    },
```

**Expected Outcomes**
- The warnings mentioned above will no longer appear when running pnpm core build.
- CSS styles will be built accurately without omissions, improving UI stability.
- The project's Node.js version requirement is now clear, allowing all team members to work in a consistent environment.