### PR TITLE
ci: change ci trigger

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,8 +5,6 @@ on:
         branches:
             - main
     pull_request:
-        branches:
-            - main
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request includes a small change to the GitHub Actions workflow configuration in `.github/workflows/quality.yml`. The change removes the `branches` filter under the `pull_request` trigger, allowing the workflow to run for pull requests targeting any branch.