### PR TITLE
feat: update theme storage keys for layout components

### DIFF
--- a/apps/website/src/app/(home)/layout.tsx
+++ b/apps/website/src/app/(home)/layout.tsx
@@ -14,6 +14,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <ThemeProvider
             config={{
                 appearance: 'dark',
+                storageKey: `theme-home`,
             }}
         >
             <HomeLayout

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import type { ReactNode } from 'react';
 
 import { ThemeProvider, ThemeScript } from '@vapor-ui/core';
 import { RootProvider } from 'fumadocs-ui/provider';
 import { Inter } from 'next/font/google';
+import { usePathname } from 'next/navigation';
 
 import DefaultSearchDialog from '~/components/search/search';
 
@@ -13,12 +16,14 @@ const inter = Inter({
 });
 
 export default function Layout({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
     return (
         <html lang="ko" className={inter.className} suppressHydrationWarning>
             <head>
                 <ThemeScript
                     config={{
                         appearance: 'light',
+                        storageKey: pathname === '/' ? 'theme-home' : `theme-index`,
                     }}
                 />
                 <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -33,6 +38,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                     <ThemeProvider
                         config={{
                             appearance: 'light',
+                            storageKey: `theme-index`,
                         }}
                     >
                         {children}


### PR DESCRIPTION
### PR: Prevent Theme Sync Between Tabs & Fix FOUC

This PR introduces a path-based `storageKey` for theme state to:

* Prevent theme synchronization across tabs

#### Key Changes

* **Home Layout**: Sets `storageKey: 'theme-home'`
* **Root Layout**: Adds `'use client'` and uses `usePathname` to dynamically assign `storageKey` (`theme-home` or `theme-index`)
* Ensures `ThemeScript` and `ThemeProvider` share the same key for consistent theme on load

#### Benefits

* Each tab maintains its own theme state
* No flicker or incorrect theme during load or refresh
