### PR TITLE
docs: add sidebar styling to docs layout configuration

### DIFF
--- a/apps/website/src/app/layout.config.tsx
+++ b/apps/website/src/app/layout.config.tsx
@@ -22,6 +22,9 @@ export const baseOptions: BaseLayoutProps = {
 export const docsOptions: DocsLayoutProps = {
     ...baseOptions,
     tree: source.pageTree,
+    sidebar: {
+        className: 'md:bg-[var(--vapor-color-background-normal)]',
+    },
 };
 
 export const playgroundOptions: NotebookLayoutProps = {


### PR DESCRIPTION
🔧 Summary
This PR enhances the docsOptions configuration in apps/website/src/app/layout.config.tsx by adding a sidebar property that allows passing a custom className for styling.

Notably, it addresses a UI issue where the[ default sidebar had a transparent background ](https://github.com/fuma-nama/fumadocs/blob/bbe2e7d7b7dd324f4820cbe5fa948ebe09b9cb51/packages/ui/src/layouts/notebook.tsx#L120)(md:bg-transparent), which interfered with custom theming. The new className field enables overriding this with a custom background via CSS variables. This change also results in a visual update to the sidebar appearance, ensuring consistent theming across screen sizes.

### 📸 UI Change Overview (Before vs After)
| Before | After |
|--------|-------|
| ![Screenshot 2025-07-03 at 10 35 02](https://github.com/user-attachments/assets/125d1286-1d6b-4b26-a191-9a8e30b1a8fa) | ![Screenshot 2025-07-03 at 10 35 35](https://github.com/user-attachments/assets/5bc10aab-cd11-42e0-