### PR TITLE
refactor: replace image components with icon components for navigation links

### DIFF
--- a/apps/website/src/constants/site-links.tsx
+++ b/apps/website/src/constants/site-links.tsx
@@ -1,50 +1,23 @@
+import { DiscordColorIcon, FigmaColorIcon, GithubIcon } from '@vapor-ui/icons';
 import type { LinkItemType } from 'fumadocs-ui/layouts/links';
-import Image from 'next/image';
 
 export const navLinks = [
     {
-        icon: (
-            <div className="relative inline-block w-5 h-5">
-                <Image
-                    src="/icons/figma-color.svg"
-                    alt="Figma"
-                    fill
-                    style={{ objectFit: 'contain' }}
-                />
-            </div>
-        ),
+        icon: <FigmaColorIcon size={20} />,
         text: 'Figma',
         url: 'https://www.figma.com/community/file/1508829832204351721/vapor-design-system',
         label: 'Vapor figma comunity file',
         type: 'icon',
     },
     {
-        icon: (
-            <div className="relative inline-block w-5 h-5">
-                <Image
-                    src="/icons/discord-color.svg"
-                    alt="Discord"
-                    fill
-                    style={{ objectFit: 'contain' }}
-                />
-            </div>
-        ),
+        icon: <DiscordColorIcon size={20} />,
         text: 'Discord',
         url: 'https://discord.gg/7Z8Ecur63D',
         label: 'Vapor Discord comunity',
         type: 'icon',
     },
     {
-        icon: (
-            <div className="relative inline-block w-5 h-5">
-                <Image
-                    src="/icons/github-color.svg"
-                    alt="Github"
-                    fill
-                    style={{ objectFit: 'contain' }}
-                />
-            </div>
-        ),
+        icon: <GithubIcon size={20} />,
         text: 'Github',
         url: 'https://github.com/goorm-dev/vapor-ui',
         label: 'Vapor Github',


### PR DESCRIPTION
This pull request refactors the `navLinks` icons in `apps/website/src/constants/site-links.tsx` to use pre-built components from the `@vapor-ui/icons` package instead of custom `Image` components. This change simplifies the code and improves maintainability.

Refactoring for icon components:

* Replaced custom `Image` components with pre-built icon components (`FigmaColorIcon`, `DiscordColorIcon`, `GithubIcon`) from `@vapor-ui/icons`. This eliminates the need for manual styling and ensures consistent icon rendering.