### PR TITLE
ci: add checkout action to labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 release:
-    - head-branch: ['^changeset-release/release-test$']
+    - head-branch: ['^changeset-release/main$']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,4 @@
 name: 'Pull Request Labeler'
-
 on:
     - pull_request_target
 
@@ -10,9 +9,6 @@ jobs:
             pull-requests: write
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4 # Uploads repository content to the runner
-
             - uses: actions/labeler@v5
               with:
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  configuration-path: '.github/labeler.yml'
+                  sync-labels: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/labeler.yml` to include a new step for checking out the repository content.

Workflow configuration changes:

* [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bR13-R14): Added a step using `actions/checkout@v4` to upload repository content to the runner before executing the labeler action.