### PR TITLE
fix(core): Fix "typeof vapor.element" type error on production

### DIFF
--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -9,7 +9,7 @@ import { createSplitProps } from '~/utils/create-split-props';
 
 import * as styles from './badge.css';
 
-type BadgePrimitiveProps = Omit<ComponentPropsWithoutRef<typeof vapor.span>, 'color'>;
+type BadgePrimitiveProps = Omit<ComponentPropsWithoutRef<'span'>, 'color'>;
 type BadgeVariants = MergeRecipeVariants<typeof styles.root>;
 
 interface BadgeProps extends BadgePrimitiveProps, BadgeVariants {}

--- a/packages/core/src/components/box/box.tsx
+++ b/packages/core/src/components/box/box.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 
 import { vapor } from '~/libs/factory';
 
-interface BoxProps extends ComponentPropsWithoutRef<typeof vapor.div> {}
+interface BoxProps extends ComponentPropsWithoutRef<'div'> {}
 
 const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
     return <vapor.div ref={ref} {...props} />;

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -9,7 +9,7 @@ import { createSplitProps } from '~/utils/create-split-props';
 
 import * as styles from './button.css';
 
-type ButtonPrimitiveProps = Omit<ComponentPropsWithoutRef<typeof vapor.button>, 'color'>;
+type ButtonPrimitiveProps = Omit<ComponentPropsWithoutRef<'button'>, 'color'>;
 type ButtonVariants = MergeRecipeVariants<typeof styles.root>;
 
 interface ButtonProps extends ButtonPrimitiveProps, ButtonVariants {}

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -13,7 +13,7 @@ import * as styles from './callout.css';
  * Callout
  * -----------------------------------------------------------------------------------------------*/
 
-type CalloutPrimitiveProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type CalloutPrimitiveProps = ComponentPropsWithoutRef<'div'>;
 type CalloutVariants = MergeRecipeVariants<typeof styles.root>;
 
 interface CalloutProps extends Omit<CalloutPrimitiveProps, 'color'>, CalloutVariants {}

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -11,7 +11,7 @@ import * as styles from './card.css';
  * Card.Root
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardRootProps extends ComponentPropsWithoutRef<typeof vapor.div> {}
+interface CardRootProps extends ComponentPropsWithoutRef<'div'> {}
 
 const Root = forwardRef<HTMLDivElement, CardRootProps>(({ className, children, ...props }, ref) => {
     return (
@@ -26,7 +26,7 @@ Root.displayName = 'Card';
  * Card.Header
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardHeaderProps extends ComponentPropsWithoutRef<typeof vapor.div> {}
+interface CardHeaderProps extends ComponentPropsWithoutRef<'div'> {}
 
 const Header = forwardRef<HTMLDivElement, CardHeaderProps>(
     ({ className, children, ...props }, ref) => {
@@ -43,7 +43,7 @@ Header.displayName = 'Card.Header';
  * Card.Body
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardBodyProps extends ComponentPropsWithoutRef<typeof vapor.div> {}
+interface CardBodyProps extends ComponentPropsWithoutRef<'div'> {}
 
 const Body = forwardRef<HTMLDivElement, CardBodyProps>(({ className, children, ...props }, ref) => {
     return (
@@ -58,7 +58,7 @@ Body.displayName = 'Card.Body';
  * Card.Footer
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardFooterProps extends ComponentPropsWithoutRef<typeof vapor.div> {}
+interface CardFooterProps extends ComponentPropsWithoutRef<'div'> {}
 
 const Footer = forwardRef<HTMLDivElement, CardFooterProps>(
     ({ className, children, ...props }, ref) => {

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -214,7 +214,7 @@ Description.displayName = 'Dialog.Description';
  * Dialog.Header
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveHeaderProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type PrimitiveHeaderProps = ComponentPropsWithoutRef<'div'>;
 interface DialogHeaderProps extends PrimitiveHeaderProps {}
 
 const Header = forwardRef<HTMLDivElement, DialogHeaderProps>(({ className, ...props }, ref) => {
@@ -226,7 +226,7 @@ Header.displayName = 'Dialog.Header';
  * Dialog.Body
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveBodyProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type PrimitiveBodyProps = ComponentPropsWithoutRef<'div'>;
 interface DialogBodyProps extends PrimitiveBodyProps {}
 
 const Body = forwardRef<HTMLDivElement, DialogBodyProps>(({ className, ...props }, ref) => {
@@ -238,7 +238,7 @@ Body.displayName = 'Dialog.Body';
  * Dialog.Footer
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveFooterProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type PrimitiveFooterProps = ComponentPropsWithoutRef<'div'>;
 interface DialogFooterProps extends PrimitiveFooterProps {}
 
 const Footer = forwardRef<HTMLDivElement, DialogFooterProps>(({ className, ...props }, ref) => {

--- a/packages/core/src/components/flex/flex.tsx
+++ b/packages/core/src/components/flex/flex.tsx
@@ -5,7 +5,7 @@ import { vapor } from '~/libs/factory';
 import { createSplitProps } from '~/utils/create-split-props';
 
 type FlexVariants = { inline?: boolean };
-type FlexPrimitiveProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type FlexPrimitiveProps = ComponentPropsWithoutRef<'div'>;
 
 interface FlexProps extends FlexPrimitiveProps, FlexVariants {}
 

--- a/packages/core/src/components/grid/grid.tsx
+++ b/packages/core/src/components/grid/grid.tsx
@@ -13,7 +13,7 @@ import * as styles from './grid.css';
  * Grid
  * -----------------------------------------------------------------------------------------------*/
 
-type GridPrimitiveProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type GridPrimitiveProps = ComponentPropsWithoutRef<'div'>;
 type GridVariants = MergeRecipeVariants<typeof styles.root> & {
     inline?: boolean;
     templateRows?: string;
@@ -58,7 +58,7 @@ Root.displayName = 'Grid';
  * Grid.Item
  * -----------------------------------------------------------------------------------------------*/
 
-type GridItemPrimitiveProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type GridItemPrimitiveProps = ComponentPropsWithoutRef<'div'>;
 type GridItemVariants = { rowSpan?: string; colSpan?: string };
 
 interface GridItemProps extends GridItemPrimitiveProps, GridItemVariants {}

--- a/packages/core/src/components/text-input/text-input.tsx
+++ b/packages/core/src/components/text-input/text-input.tsx
@@ -36,7 +36,7 @@ const [TextInputProvider, useTextInputContext] = createContext<TextInputContextT
  * TextInput
  * -----------------------------------------------------------------------------------------------*/
 
-type TextInputPrimitiveProps = ComponentPropsWithoutRef<typeof vapor.div>;
+type TextInputPrimitiveProps = ComponentPropsWithoutRef<'div'>;
 
 interface TextInputRootProps
     extends Omit<TextInputPrimitiveProps, keyof TextInputSharedProps>,
@@ -79,7 +79,7 @@ Root.displayName = 'TextInput.Root';
  * TextInput.Label
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveLabelProps = ComponentPropsWithoutRef<typeof vapor.label>;
+type PrimitiveLabelProps = ComponentPropsWithoutRef<'label'>;
 interface TextInputLabelProps extends PrimitiveLabelProps {}
 
 const Label = forwardRef<HTMLLabelElement, TextInputLabelProps>(
@@ -102,7 +102,7 @@ Label.displayName = 'TextInput.Label';
  * TextInput.Field
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveInputProps = ComponentPropsWithoutRef<typeof vapor.input>;
+type PrimitiveInputProps = ComponentPropsWithoutRef<'input'>;
 interface TextInputFieldProps extends Omit<PrimitiveInputProps, keyof TextInputSharedProps> {}
 
 const Field = forwardRef<HTMLInputElement, TextInputFieldProps>(

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -6,7 +6,7 @@ import { vapor } from '~/libs/factory';
 import { foregroundSprinkles, typographySprinkles } from '~/styles/sprinkles';
 import type { Foreground, Typography } from '~/styles/sprinkles';
 
-interface TextProps extends React.ComponentPropsWithoutRef<typeof vapor.span> {
+interface TextProps extends React.ComponentPropsWithoutRef<'span'> {
     typography?: Typography;
     foreground?: Foreground;
 }


### PR DESCRIPTION
Change type error for `typeof vapor.div` is not `VaporForwardRefComponent<'div'>`.

Related issue https://github.com/goorm-dev/vapor-ui/pull/67#discussion_r2188440580

## Code

![스크린샷 2025-07-07 오후 12 54 15](https://github.com/user-attachments/assets/ceb7a9ee-233c-460e-a6e1-062ac678b008)

## Production

![스크린샷 2025-07-07 오후 12 54 56](https://github.com/user-attachments/assets/e6cae80e-af12-4f29-a8ed-5d24632cc96c)
