### PR TITLE
style: update variable usage in size-cell component for consistency

### DIFF
--- a/apps/website/src/components/foundation-size-tabs/size-cell.tsx
+++ b/apps/website/src/components/foundation-size-tabs/size-cell.tsx
@@ -22,10 +22,10 @@ const SemanticSizeRow = ({ sizeType = 'width', name, value }: SemanticSizeRowPro
             <td>
                 <div
                     style={{
-                        width: isBorderRadius ? ' 5rem' : `var(--${name})`,
-                        height: isBorderRadius ? ' 5rem' : `var(--${name})`,
+                        width: isBorderRadius ? ' 5rem' : `var(${name})`,
+                        height: isBorderRadius ? ' 5rem' : `var(${name})`,
                         backgroundColor: 'var(--vapor-color-blue-100)',
-                        borderRadius: isBorderRadius ? `var(--${name})` : '0',
+                        borderRadius: isBorderRadius ? `var(${name})` : '0',
                     }}
                 />
             </td>


### PR DESCRIPTION
## Fix incorrect CSS-variable reference in foundation Size Tabs

### Description
The Size Tabs preview cells were incorrectly referencing CSS variables with an extra --, e.g. var(----vapor-size-…).

### This update:
Replaces var(--${name}) with var(${name}) for width, height, and borderRadius.
Ensures the preview boxes now pick up the correct size and radius tokens.
