### PR TITLE
chore: tsup spliting update

### DIFF
--- a/.changeset/quiet-berries-act.md
+++ b/.changeset/quiet-berries-act.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+chore: tsup spliting disable

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -83,7 +83,7 @@ export default defineConfig([
         ...commonConfig,
         entry: ['src/components/*/index.ts'],
         outDir: OUT_DIR,
-        splitting: true,
+        splitting: false,
         esbuildPlugins: [
             vanillaExtractPlugin({
                 outputCss: true,


### PR DESCRIPTION
Temporarily disable `tsup` splitting due to CSS fetching issues.