### PR TITLE
fix(createThemeConfig): Support RSC

### DIFF
--- a/.changeset/brave-forks-appear.md
+++ b/.changeset/brave-forks-appear.md
@@ -1,6 +1,6 @@
 ---
-'@vapor-ui/core': minor
-'website': minor
+'@vapor-ui/core': patch
+'website': patch
 ---
 
-feat(createThemeConfig): support RSC
+fix(createThemeConfig): support RSC

--- a/.changeset/brave-forks-appear.md
+++ b/.changeset/brave-forks-appear.md
@@ -1,0 +1,6 @@
+---
+'@vapor-ui/core': minor
+'website': minor
+---
+
+feat(createThemeConfig): support RSC

--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -15,6 +15,8 @@ description: Vapor UI 설치를 위한 가이드.
 
 Vapor UI를 설치하세요:
 
+{/* prettier-ignore */}
+
 ```package-install
 npm install @vapor-ui/core
 ```
@@ -25,9 +27,11 @@ npm install @vapor-ui/core
 
 애플리케이션 루트에 스타일을 추가하세요:
 
+> Next.js의 경우, `layout.tsx` 파일에 스타일을 추가해야 합니다.
+
 {/* prettier-ignore */}
-<Tabs items={[".jsx", ".css"]} defaultValue=".jsx">
-  <Tab value=".jsx">
+<Tabs items={[".tsx", ".css"]} defaultValue=".tsx">
+  <Tab value=".tsx">
   ```tsx
   import '@vapor-ui/core/styles.css'; 
   ```

--- a/apps/website/content/docs/getting-started/theming.mdx
+++ b/apps/website/content/docs/getting-started/theming.mdx
@@ -30,8 +30,10 @@ description: Vapor UI 테마 시스템을 설정하는 방법
 3. **Root layout.tsx에 적용**
 
     ```tsx
-    import { createThemeConfig, ThemeScript, ThemeProvider } from "@vapor-ui/core";
-    import "@vapor-ui/core/styles.css";
+    import { ThemeProvider, ThemeScript } from '@vapor-ui/core';
+    import '@vapor-ui/core/dist/styles.css';
+
+    // createThemeConfig를 상단에 추가하거나, 별도 설정 파일에서 import합니다.
 
     export default function RootLayout({ children }) {
         return (

--- a/apps/website/content/docs/getting-started/theming.mdx
+++ b/apps/website/content/docs/getting-started/theming.mdx
@@ -16,27 +16,26 @@ description: Vapor UI 테마 시스템을 설정하는 방법
 2. **테마 설정 파일 생성**  
    (예시: `lib/theme.config.ts`)
 
-    ```ts
+    ```tsx
     import { createThemeConfig } from '@vapor-ui/core';
 
     export const themeConfig = createThemeConfig({
-        appearance: 'system', // 'light', 'dark', 'system'
+        appearance: 'light',
         radius: 'full',
         scaling: 1.0,
-        storageKey: 'my-next-app-theme',
+        storageKey: 'my-vapor-theme',
     });
     ```
 
 3. **Root layout.tsx에 적용**
 
     ```tsx
-    import { themeConfig } from '@/lib/theme.config';
-    import { ThemeProvider, ThemeScript } from '@vapor-ui/core';
-    import '@vapor-ui/core/dist/styles.css';
+    import { createThemeConfig, ThemeScript, ThemeProvider } from "@vapor-ui/core";
+    import "@vapor-ui/core/styles.css";
 
     export default function RootLayout({ children }) {
         return (
-            <html lang="en" suppressHydrationWarning>
+            <html suppressHydrationWarning>
                 <head>
                     <ThemeScript config={themeConfig} />
                 </head>
@@ -57,7 +56,7 @@ description: Vapor UI 테마 시스템을 설정하는 방법
     ```bash
     npm install @vapor-ui/core
     ```
-
+{/* 
 2. **index.html에 FOUC 방지 스크립트 추가**
 
     ```html
@@ -87,9 +86,9 @@ description: Vapor UI 테마 시스템을 설정하는 방법
             root.style.setProperty('--vapor-scale-factor', scaleFactor.toString());
         })();
     </script>
-    ```
+    ``` */}
 
-3. **ThemeProvider 설정**
+2. **ThemeProvider 설정**
 
     ```tsx
     // src/main.tsx
@@ -98,9 +97,9 @@ description: Vapor UI 테마 시스템을 설정하는 방법
 
     const themeConfig = createThemeConfig({
         appearance: 'light',
-        radius: 'md',
+        radius: 'full',
         scaling: 1.0,
-        storageKey: 'my-vite-app-theme',
+        storageKey: 'my-vapor-theme',
     });
 
     ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/core/src/components/card/card.css.ts
+++ b/packages/core/src/components/card/card.css.ts
@@ -8,7 +8,7 @@ export const root = layerStyle('vapor-component', {
     border: `1px solid ${vars.color.border.normal}`,
     borderRadius: vars.size.borderRadius[300],
 
-    backgroundColor: vars.color.background.normal,
+    backgroundColor: vars.color.background['normal-lighter'],
 });
 
 export const header = layerStyle('vapor-component', {

--- a/packages/core/src/components/create-theme-config/create-theme-config.tsx
+++ b/packages/core/src/components/create-theme-config/create-theme-config.tsx
@@ -1,0 +1,54 @@
+import { THEME_CONFIG, type ThemeState } from '../theme-provider';
+
+/* -------------------------------------------------------------------------------------------------
+ * Constants & Core Types
+ * -----------------------------------------------------------------------------------------------*/
+const DEFAULT_THEME: ThemeState = {
+    appearance: 'light',
+    radius: 'md',
+    scaling: 1,
+};
+
+interface VaporThemeConfig extends Partial<ThemeState> {
+    /** localStorage key for persistence */
+    storageKey?: string;
+    /** CSP nonce value */
+    nonce?: string;
+    /** Enable system theme detection (for future extension) */
+    enableSystemTheme?: boolean;
+}
+interface ResolvedThemeConfig extends ThemeState {
+    storageKey: string;
+    nonce?: string;
+    enableSystemTheme: boolean;
+}
+
+/**
+ * Creates a complete configuration object by merging user config with defaults
+ *
+ * @example
+ * ```tsx
+ * const config = createThemeConfig({
+ *   appearance: 'dark',
+ *   storageKey: 'my-app-theme'
+ * });
+ * ```
+ */
+const createThemeConfig = (userConfig?: VaporThemeConfig): ResolvedThemeConfig => {
+    const {
+        storageKey = THEME_CONFIG.STORAGE_KEY,
+        nonce,
+        enableSystemTheme = false,
+        ...themeProps
+    } = userConfig ?? {};
+
+    return {
+        ...DEFAULT_THEME,
+        ...themeProps,
+        storageKey,
+        nonce,
+        enableSystemTheme,
+    };
+};
+
+export { createThemeConfig };

--- a/packages/core/src/components/create-theme-config/index.ts
+++ b/packages/core/src/components/create-theme-config/index.ts
@@ -1,0 +1,1 @@
+export * from './create-theme-config';

--- a/packages/core/src/components/theme-provider/theme-injector.ts
+++ b/packages/core/src/components/theme-provider/theme-injector.ts
@@ -1,12 +1,3 @@
-/* -------------------------------------------------------------------------------------------------
- * Constants & Core Types
- * -----------------------------------------------------------------------------------------------*/
-const DEFAULT_THEME: ThemeState = {
-    appearance: 'light',
-    radius: 'md',
-    scaling: 1,
-};
-
 const DARK_CLASS_NAME = 'vapor-dark-theme';
 const LIGHT_CLASS_NAME = 'vapor-light-theme';
 
@@ -31,19 +22,6 @@ type Appearance = keyof typeof THEME_CONFIG.CLASS_NAMES;
 type Radius = keyof typeof THEME_CONFIG.RADIUS_FACTOR_MAP;
 type Scaling = number;
 
-interface VaporThemeConfig extends Partial<ThemeState> {
-    /** localStorage key for persistence */
-    storageKey?: string;
-    /** CSP nonce value */
-    nonce?: string;
-    /** Enable system theme detection (for future extension) */
-    enableSystemTheme?: boolean;
-}
-interface ResolvedThemeConfig extends ThemeState {
-    storageKey: string;
-    nonce?: string;
-    enableSystemTheme: boolean;
-}
 interface ThemeState {
     appearance: Appearance;
     radius: Radius;
@@ -118,38 +96,9 @@ const themeInjectScript = (
     })();
 };
 
-/**
- * Creates a complete configuration object by merging user config with defaults
- *
- * @example
- * ```tsx
- * const config = createThemeConfig({
- *   appearance: 'dark',
- *   storageKey: 'my-app-theme'
- * });
- * ```
- */
-const createThemeConfig = (userConfig?: VaporThemeConfig): ResolvedThemeConfig => {
-    const {
-        storageKey = THEME_CONFIG.STORAGE_KEY,
-        nonce,
-        enableSystemTheme = false,
-        ...themeProps
-    } = userConfig ?? {};
-
-    return {
-        ...DEFAULT_THEME,
-        ...themeProps,
-        storageKey,
-        nonce,
-        enableSystemTheme,
-    };
-};
-
 export {
     THEME_CONFIG,
     themeInjectScript,
-    createThemeConfig,
     type ThemeConfig,
     type Appearance,
     type Radius,

--- a/packages/core/src/components/theme-provider/theme-provider.tsx
+++ b/packages/core/src/components/theme-provider/theme-provider.tsx
@@ -5,7 +5,8 @@ import { createContext, memo, useCallback, useContext, useEffect, useMemo, useSt
 
 import { RADIUS_FACTOR_VAR_NAME, SCALE_FACTOR_VAR_NAME } from '~/styles/global-var.css';
 
-import { THEME_CONFIG, createThemeConfig, themeInjectScript } from './theme-injector';
+import { createThemeConfig } from '../create-theme-config';
+import { THEME_CONFIG, themeInjectScript } from './theme-injector';
 import type { Appearance, Radius, Scaling, ThemeState } from './theme-injector';
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,4 @@ export * from './components/radio-group';
 export * from './components/checkbox';
 export * from './components/switch';
 export * from './components/callout';
+export * from './components/create-theme-config';

--- a/packages/core/src/styles/global.css.ts
+++ b/packages/core/src/styles/global.css.ts
@@ -1,6 +1,7 @@
 import { globalStyle } from '@vanilla-extract/css';
 
 import { layers } from './layers.css';
+import { vars } from './vars.css';
 
 globalStyle('*', {
     '@layer': {
@@ -8,9 +9,18 @@ globalStyle('*', {
             boxSizing: 'border-box',
             margin: 0,
             padding: 0,
-            fontFamily: `Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif`,
+            fontFamily: vars.typography.fontFamily.sans,
             WebkitFontSmoothing: 'antialiased',
             MozOsxFontSmoothing: 'grayscale',
+        },
+    },
+});
+
+globalStyle('html, body', {
+    '@layer': {
+        [layers.reset]: {
+            backgroundColor: vars.color.background.normal,
+            color: vars.color.foreground.normal,
         },
     },
 });


### PR DESCRIPTION
<details>
<summary>Korean</summary>

* RSC (React Server Components) 환경에서 `createThemeConfig`가 지원되지 않던 문제를 해결했습니다.
* Theming 관련 문서 내용을 최신 변경사항에 맞게 올바르게 수정했습니다.

</details>

<br/>

- Fixed an issue where createThemeConfig was not supported in the RSC (React Server Components) environment.
- Updated the theming documentation to reflect the recent changes accurately.