### PR TITLE
docs : Update installation instructions to use the latest version of @vapor-ui

### DIFF
--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -16,9 +16,8 @@ description: Vapor UI 설치를 위한 가이드.
 Vapor UI를 설치하세요:
 
 {/* prettier-ignore */}
-
 ```package-install
-npm install @vapor-ui/core
+npm install @vapor-ui/core@latest
 ```
 
 <br />

--- a/apps/website/content/docs/getting-started/theming.mdx
+++ b/apps/website/content/docs/getting-started/theming.mdx
@@ -9,8 +9,8 @@ description: Vapor UI 테마 시스템을 설정하는 방법
 
 1. **패키지 설치**
 
-    ```bash
-    npm install @vapor-ui/core
+    ```package-install
+    npm install @vapor-ui/core@latest
     ```
 
 2. **테마 설정 파일 생성**  
@@ -53,13 +53,13 @@ description: Vapor UI 테마 시스템을 설정하는 방법
 
 ## 2. Vite
 
-1. **패키지 설치**
+1.  **패키지 설치**
 
-    ```bash
-    npm install @vapor-ui/core
-    ```
-{/* 
-2. **index.html에 FOUC 방지 스크립트 추가**
+```package-install
+npm install @vapor-ui/core@latest
+```
+
+2.  **index.html에 FOUC 방지 스크립트 추가**
 
     ```html
     <!-- public/index.html -->
@@ -88,9 +88,9 @@ description: Vapor UI 테마 시스템을 설정하는 방법
             root.style.setProperty('--vapor-scale-factor', scaleFactor.toString());
         })();
     </script>
-    ``` */}
+    ```
 
-2. **ThemeProvider 설정**
+3.  **ThemeProvider 설정**
 
     ```tsx
     // src/main.tsx

--- a/apps/website/content/docs/theming/next-app.mdx
+++ b/apps/website/content/docs/theming/next-app.mdx
@@ -14,7 +14,7 @@ Next.js의 App Router에서 서버 사이드 렌더링(SSR)과 스트리밍 기�
 #### 1단계: 패키지 설치
 
 ```bash
-npm install @vapor-ui/core
+npm install @vapor-ui/core@latest
 ```
 
 #### 2단계: 테마 설정 파일 생성 (선택사항이지만 권장)
@@ -41,12 +41,11 @@ export const themeConfig = createThemeConfig({
 // app/layout.tsx
 import { themeConfig } from '@/lib/theme.config';
 import { ThemeProvider, ThemeScript } from '@vapor-ui/core';
-import type { Metadata } from 'next';
-
 // 설정 파일 경로
 
 // 필수: 스타일 시트를 임포트합니다.
 import '@vapor-ui/core/dist/styles.css';
+import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
     title: 'Create Next App',
@@ -94,6 +93,8 @@ export default function RootLayout({
 import { useEffect, useState } from 'react';
 
 import { useTheme } from '@vapor-ui/core';
+
+// components/ThemeToggleButton.tsx
 
 // components/ThemeToggleButton.tsx
 

--- a/apps/website/content/docs/theming/vite.mdx
+++ b/apps/website/content/docs/theming/vite.mdx
@@ -26,7 +26,7 @@ FOUC를 방지하려면, React가 실행되기 전에 `localStorage`의 테마 �
 먼저 `@vapor-ui/core`를 설치합니다.
 
 ```bash
-npm install @vapor-ui/core
+npm install @vapor-ui/core@latest
 ```
 
 ### 2단계: `index.html`에 FOUC 방지 스크립트 추가

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ Vapor UI core components library.
 
 ```bash
 # With npm
-npm install @vapor-ui/core @vapor-ui/hooks @vapor-ui/icons
+npm install @vapor-ui/core@latest @vapor-ui/hooks@latest @vapor-ui/icons@latest
 ```
 
 ## License


### PR DESCRIPTION
This pull request updates installation instructions across multiple documentation files to explicitly recommend installing the latest versions of Vapor UI packages. It also includes minor improvements to code organization in the Next.js theming guide for better readability.

### 📦 Installation Instruction Updates

The following files now use `@latest` in their `npm install` commands to ensure consistency and clarity when installing Vapor UI packages:

- `apps/website/content/docs/getting-started/installation.mdx`
- `apps/website/content/docs/getting-started/theming.mdx`  
- `apps/website/content/docs/theming/next-app.mdx`
- `apps/website/content/docs/theming/vite.mdx`
- `packages/core/README.md`

### 🧹 Code Organization Improvements

- Reordered `import type { Metadata } from 'next'` for clearer logical grouping of imports in `next-app.mdx`.
- Removed a duplicate comment in the `ThemeToggleButton` component section for better clarity.

These changes help ensure developers consistently install the most recent stable release and improve maintainability across the documentation.
