### PR TITLE
build: remove dist/types directory

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,15 +14,15 @@
     "homepage": "https://github.com/goorm-dev/vapor-ui",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
-    "types": "./dist/types/index.d.ts",
+    "types": "./dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/types/index.d.ts",
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
         "./*": {
-            "types": "./dist/types/components/*/index.d.ts",
+            "types": "./dist/components/*/index.d.ts",
             "import": "./dist/components/*/index.js",
             "require": "./dist/components/*/index.cjs"
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
         "url": "https://github.com/goorm-dev/vapor-ui/issues"
     },
     "scripts": {
-        "build": "tsup",
+        "build": "rimraf dist && tsup",
         "lint": "eslint ./src",
         "format": "prettier --write \"./src/**/*.{ts,tsx,md}\"",
         "format:check": "prettier --check \"./src/**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
- .d.ts 파일을 dist/types 하위가 아니라, dist 및 dist/components 하위에 생성
- flex, box처럼 .css.ts 파일이 없는 컴포넌트에서는 index.css 임포트 구문 제거