### PR TITLE
feat: add layout recipes

### DIFF
--- a/packages/core/src/components/box/box.stories.tsx
+++ b/packages/core/src/components/box/box.stories.tsx
@@ -9,96 +9,46 @@ export const Default = {
     render: () => {
         return (
             <Box
-                style={{
-                    borderRadius: 'var(--vapor-size-borderRadius-300)',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--vapor-size-dimension-500)',
-                    padding: 'var(--vapor-size-dimension-800)',
-                    background: 'var(--vapor-color-gray-500)',
-                }}
+                borderRadius="$300"
+                display="flex"
+                flexDirection="column"
+                gap="$500"
+                padding="$800"
+                backgroundColor="$gray-500"
             >
                 <Box style={{ backgroundColor: 'red' }} asChild>
                     <Button>sadfasdf</Button>
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        padding: 'var(--vapor-size-dimension-900)',
-                        backgroundColor: 'blue',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    padding="$900"
+                    style={{ backgroundColor: 'blue' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'green',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'green' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'green',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'yellow' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'green',
-                    }}
-                >
-                    1
-                </Box>
-                <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'green',
-                    }}
-                >
-                    1
-                </Box>
-                <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'yellow',
-                    }}
-                >
-                    1
-                </Box>
-                <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'black',
-                    }}
-                >
-                    1
-                </Box>
-                <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'black',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'black' }}
                 >
                     1
                 </Box>
@@ -107,23 +57,11 @@ export const Default = {
                     <a href="asd">as anchor</a>
                 </Box>
 
-                <Box
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        gap: 'var(--vapor-size-dimension-200)',
-                    }}
-                >
+                <Box display="flex" flexDirection="row" gap="$200">
                     <span style={{ border: '1px solid' }}>row 1</span>
                     <span style={{ border: '1px solid' }}>row 2</span>
 
-                    <Box
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 'var(--vapor-size-dimension-100)',
-                        }}
-                    >
+                    <Box display="flex" flexDirection="column" gap="$100">
                         <span style={{ border: '1px solid' }}>row {'>'} nested column 1</span>
                         <span style={{ border: '1px solid' }}>row {'>'} nested column 2</span>
                     </Box>
@@ -137,56 +75,46 @@ export const TestBed = {
     render: () => {
         return (
             <Box
-                style={{
-                    borderRadius: 'var(--vapor-size-borderRadius-300)',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--vapor-size-dimension-200)',
-                    padding: 'var(--vapor-size-dimension-500)',
-                    background: 'var(--vapor-color-gray-500)',
-                }}
+                borderRadius="$300"
+                display="flex"
+                flexDirection="column"
+                gap="$200"
+                padding="$500"
+                backgroundColor="$gray-500"
             >
                 <Box style={{ backgroundColor: 'red' }} asChild>
                     <Button>I'm Button</Button>
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        padding: 'var(--vapor-size-space-900)',
-                        backgroundColor: 'blue',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    padding="$900"
+                    style={{ backgroundColor: 'blue' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'green',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'green' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'yellow',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'yellow' }}
                 >
                     1
                 </Box>
                 <Box
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        backgroundColor: 'black',
-                    }}
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    style={{ backgroundColor: 'black' }}
                 >
                     1
                 </Box>
@@ -195,23 +123,11 @@ export const TestBed = {
                     <a href="asd">as anchor</a>
                 </Box>
 
-                <Box
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        gap: 'var(--vapor-size-dimension-200)',
-                    }}
-                >
+                <Box display="flex" flexDirection="row" gap="$200">
                     <span style={{ border: '1px solid' }}>row 1</span>
                     <span style={{ border: '1px solid' }}>row 2</span>
 
-                    <Box
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 'var(--vapor-size-dimension-100)',
-                        }}
-                    >
+                    <Box display="flex" flexDirection="column" gap="$100">
                         <span style={{ border: '1px solid' }}>row {'>'} nested column 1</span>
                         <span style={{ border: '1px solid' }}>row {'>'} nested column 2</span>
                     </Box>
@@ -220,134 +136,3 @@ export const TestBed = {
         );
     },
 };
-// export const Default = {
-//     render: () => {
-//         return (
-//             <Box
-//                 borderRadius="$300"
-//                 display="flex"
-//                 flexDirection="column"
-//                 gap="$500"
-//                 padding="$800"
-//                 background="$gray-500"
-//             >
-//                 <Box style={{ backgroundColor: 'red' }} asChild>
-//                     <Button>sadfasdf</Button>
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     padding="$900"
-//                     style={{ backgroundColor: 'blue' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'green' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'yellow' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'black' }}
-//                 >
-//                     1
-//                 </Box>
-
-//                 <Box asChild>
-//                     <a href="asd">as anchor</a>
-//                 </Box>
-
-//                 <Box display="flex" flexDirection="row" gap="$200">
-//                     <span style={{ border: '1px solid' }}>row 1</span>
-//                     <span style={{ border: '1px solid' }}>row 2</span>
-
-//                     <Box display="flex" flexDirection="column" gap="$100">
-//                         <span style={{ border: '1px solid' }}>row {'>'} nested column 1</span>
-//                         <span style={{ border: '1px solid' }}>row {'>'} nested column 2</span>
-//                     </Box>
-//                 </Box>
-//             </Box>
-//         );
-//     },
-// };
-
-// export const TestBed = {
-//     render: () => {
-//         return (
-//             <Box
-//                 borderRadius="$300"
-//                 display="flex"
-//                 flexDirection="column"
-//                 gap="$200"
-//                 padding="$500"
-//                 background="$gray-500"
-//             >
-//                 <Box style={{ backgroundColor: 'red' }} asChild>
-//                     <Button>I'm Button</Button>
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     padding="$900"
-//                     style={{ backgroundColor: 'blue' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'green' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'yellow' }}
-//                 >
-//                     1
-//                 </Box>
-//                 <Box
-//                     display="flex"
-//                     justifyContent="center"
-//                     alignItems="center"
-//                     style={{ backgroundColor: 'black' }}
-//                 >
-//                     1
-//                 </Box>
-
-//                 <Box asChild>
-//                     <a href="asd">as anchor</a>
-//                 </Box>
-
-//                 <Box display="flex" flexDirection="row" gap="$200">
-//                     <span style={{ border: '1px solid' }}>row 1</span>
-//                     <span style={{ border: '1px solid' }}>row 2</span>
-
-//                     <Box display="flex" flexDirection="column" gap="$100">
-//                         <span style={{ border: '1px solid' }}>row {'>'} nested column 1</span>
-//                         <span style={{ border: '1px solid' }}>row {'>'} nested column 2</span>
-//                     </Box>
-//                 </Box>
-//             </Box>
-//         );
-//     },
-// };

--- a/packages/core/src/components/box/box.tsx
+++ b/packages/core/src/components/box/box.tsx
@@ -4,11 +4,23 @@ import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
+import clsx from 'clsx';
 
-interface BoxProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+import { type Sprinkles, sprinkles } from '~/styles/sprinkles.css';
 
-const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
-    return <Primitive.div ref={ref} {...props} />;
+interface BoxProps extends ComponentPropsWithoutRef<typeof Primitive.div>, Sprinkles {}
+
+const Box = forwardRef<HTMLDivElement, BoxProps>(({ className, style, ...props }, ref) => {
+    const { className: layoutClassName, style: layoutStyle, otherProps } = sprinkles(props);
+
+    return (
+        <Primitive.div
+            ref={ref}
+            className={clsx(layoutClassName, className)}
+            style={{ ...layoutStyle, ...style }}
+            {...otherProps}
+        />
+    );
 });
 Box.displayName = 'Box';
 

--- a/packages/core/src/components/button/button.stories.tsx
+++ b/packages/core/src/components/button/button.stories.tsx
@@ -19,16 +19,14 @@ export default {
         stretch: { control: 'boolean' },
     },
 } as Meta<typeof Button>;
-
 type Story = StoryObj<typeof Button>;
 
 export const Default: Story = {
     render: (args) => (
-        // <HStack gap="$200">
-        <HStack style={{ gap: 'var(--vapor-size-dimension-200)' }}>
+        <HStack gap="$200">
             <Button {...args}>Button</Button>
             <Button {...args} asChild>
-                <a href="https://Primitive.goorm.io">Link Button(Polymorphic)</a>
+                <a href="https://vapor.goorm.io">Link Button(Polymorphic)</a>
             </Button>
         </HStack>
     ),
@@ -66,12 +64,7 @@ export const TestBed: Story = {
 const Buttons = ({ color, disabled }: ButtonProps) => {
     return (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Button
-                color={color}
-                disabled={disabled}
-                variant="fill"
-                style={{ gap: 'var(--vapor-size-dimension-050)' }}
-            >
+            <Button color={color} disabled={disabled} variant="fill">
                 {upperFirst(`${color}`)}
             </Button>
             <Button color={color} disabled={disabled} variant="ghost">

--- a/packages/core/src/components/flex/flex.stories.tsx
+++ b/packages/core/src/components/flex/flex.stories.tsx
@@ -11,7 +11,7 @@ export const Default = {
             <>
                 <div>
                     <p>1. Flex / row direction / gap 050</p>
-                    <Flex style={{ backgroundColor: 'lightskyblue' }}>
+                    <Flex gap="$050" padding="$150" style={{ backgroundColor: 'lightskyblue' }}>
                         <div style={{ backgroundColor: 'red', width: '100px', height: '100px' }} />
                         <div style={{ backgroundColor: 'blue', width: '100px', height: '100px' }} />
                         <div
@@ -19,20 +19,18 @@ export const Default = {
                         />
                     </Flex>
                 </div>
-
                 <div>
                     <p>2. Inline Flex / column direction / gap 300</p>
                     <Flex
                         inline
-                        style={{
-                            flexDirection: 'column',
-                            gap: 'var(--vapor-size-dimension-300)',
-                            padding: 'var(--vapor-size-dimension-150)',
-                            backgroundColor: 'lightgray',
-                        }}
+                        gap="$300"
+                        padding="$150"
+                        flexDirection="column"
+                        style={{ backgroundColor: 'lightgray' }}
                     >
                         <div style={{ backgroundColor: 'red', width: '100px', height: '100px' }} />
                         <div style={{ backgroundColor: 'blue', width: '100px', height: '100px' }} />
+
                         <div
                             style={{ backgroundColor: 'green', width: '100px', height: '100px' }}
                         />
@@ -49,13 +47,7 @@ export const TestBed = {
             <>
                 <div>
                     <p>1. Flex / row direction / gap 050</p>
-                    <Flex
-                        style={{
-                            gap: 'var(--vapor-size-dimension-050)',
-                            padding: 'var(--vapor-size-dimension-150)',
-                            backgroundColor: 'lightskyblue',
-                        }}
-                    >
+                    <Flex gap="$050" padding="$150" style={{ backgroundColor: 'lightskyblue' }}>
                         <div style={{ backgroundColor: 'red', width: '100px', height: '100px' }} />
                         <div style={{ backgroundColor: 'blue', width: '100px', height: '100px' }} />
                         <div
@@ -63,20 +55,18 @@ export const TestBed = {
                         />
                     </Flex>
                 </div>
-
                 <div>
                     <p>2. Inline Flex / column direction / gap 300</p>
                     <Flex
                         inline
-                        style={{
-                            gap: 'var(--vapor-size-dimension-300)',
-                            padding: 'var(--vapor-size-dimension-150)',
-                            flexDirection: 'column',
-                            backgroundColor: 'lightgray',
-                        }}
+                        gap="$300"
+                        padding="$150"
+                        flexDirection="column"
+                        style={{ backgroundColor: 'lightgray' }}
                     >
                         <div style={{ backgroundColor: 'red', width: '100px', height: '100px' }} />
                         <div style={{ backgroundColor: 'blue', width: '100px', height: '100px' }} />
+
                         <div
                             style={{ backgroundColor: 'green', width: '100px', height: '100px' }}
                         />

--- a/packages/core/src/components/flex/flex.tsx
+++ b/packages/core/src/components/flex/flex.tsx
@@ -12,16 +12,10 @@ type FlexPrimitiveProps = ComponentPropsWithoutRef<typeof Box>;
 
 interface FlexProps extends FlexPrimitiveProps, FlexVariants {}
 
-const Flex = forwardRef<HTMLDivElement, FlexProps>(({ style, className, ...props }, ref) => {
-    const [flexVariants, otherProps] = createSplitProps<FlexVariants>()(props, ['inline']);
+const Flex = forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+    const [variantProps, otherProps] = createSplitProps<FlexVariants>()(props, ['inline']);
 
-    return (
-        <Box
-            style={{ display: flexVariants.inline ? 'inline-flex' : 'flex', ...style }}
-            ref={ref}
-            {...otherProps}
-        />
-    );
+    return <Box ref={ref} display={variantProps.inline ? 'inline-flex' : 'flex'} {...otherProps} />;
 });
 Flex.displayName = 'Flex';
 

--- a/packages/core/src/components/grid/grid.stories.tsx
+++ b/packages/core/src/components/grid/grid.stories.tsx
@@ -41,9 +41,9 @@ export const Default: StoryObj<typeof Grid.Root> = {
                 style={{
                     width: 400,
                     backgroundColor: 'GrayText',
-                    justifyContent: 'center',
-                    alignItems: 'center',
                 }}
+                justifyContent="center"
+                alignItems="center"
                 templateRows="repeat(3, minmax(40px, auto))"
                 templateColumns="1fr 1fr 1fr"
                 {...args}
@@ -69,9 +69,9 @@ export const TestBed: StoryObj<typeof Grid> = {
                 style={{
                     width: 400,
                     backgroundColor: 'GrayText',
-                    justifyContent: 'center',
-                    alignItems: 'center',
                 }}
+                justifyContent="center"
+                alignItems="center"
                 templateRows="repeat(3, minmax(40px, auto))"
                 templateColumns="1fr 1fr 1fr"
                 {...args}

--- a/packages/core/src/components/grid/grid.tsx
+++ b/packages/core/src/components/grid/grid.tsx
@@ -28,14 +28,14 @@ interface GridRootProps extends GridPrimitiveProps, GridVariants {}
 
 const Root = forwardRef<HTMLDivElement, GridRootProps>(
     ({ className, style, children, ...props }, ref) => {
-        const [gridRootProps, otherProps] = createSplitProps<GridVariants>()(props, [
+        const [variantProps, otherProps] = createSplitProps<GridVariants>()(props, [
             'inline',
             'templateRows',
             'templateColumns',
             'flow',
         ]);
 
-        const { inline, templateRows, templateColumns, ...variants } = gridRootProps;
+        const { inline, templateRows, templateColumns, ...variants } = variantProps;
 
         const cssVariables = assignInlineVars({
             [styles.gridTemplateRows]: templateRows,
@@ -45,7 +45,8 @@ const Root = forwardRef<HTMLDivElement, GridRootProps>(
         return (
             <Box
                 ref={ref}
-                style={{ display: inline ? 'inline-grid' : 'grid', ...cssVariables, ...style }}
+                display={inline ? 'inline-grid' : 'grid'}
+                style={{ ...cssVariables, ...style }}
                 className={clsx(styles.root(variants), className)}
                 {...otherProps}
             >

--- a/packages/core/src/components/h-stack/h-stack.stories.tsx
+++ b/packages/core/src/components/h-stack/h-stack.stories.tsx
@@ -5,6 +5,7 @@ import type { StoryObj } from '@storybook/react';
 import { vars } from '~/styles/vars.css';
 
 import { HStack } from '.';
+import { Box } from '../box';
 
 export default {
     title: 'HStack',
@@ -27,11 +28,11 @@ export const Default: StoryObj<typeof HStack> = {
     render: (args) => {
         return (
             <HStack {...args}>
-                <Box size={90}>1</Box>
-                <Box size={80}>2</Box>
-                <Box size={70}>3</Box>
-                <Box size={60}>4</Box>
-                <Box size={50}>5</Box>
+                <CustomBox size={90}>1</CustomBox>
+                <CustomBox size={80}>2</CustomBox>
+                <CustomBox size={70}>3</CustomBox>
+                <CustomBox size={60}>4</CustomBox>
+                <CustomBox size={50}>5</CustomBox>
             </HStack>
         );
     },
@@ -41,29 +42,26 @@ export const TestBed: StoryObj<typeof HStack> = {
     render: (args) => {
         return (
             <HStack {...args}>
-                <Box size={90}>1</Box>
-                <Box size={80}>2</Box>
-                <Box size={70}>3</Box>
-                <Box size={60}>4</Box>
-                <Box size={50}>5</Box>
+                <CustomBox size={90}>1</CustomBox>
+                <CustomBox size={80}>2</CustomBox>
+                <CustomBox size={70}>3</CustomBox>
+                <CustomBox size={60}>4</CustomBox>
+                <CustomBox size={50}>5</CustomBox>
             </HStack>
         );
     },
 };
 
-const Box = ({ size = 50, style, ...props }: ComponentProps<'div'> & { size?: number }) => {
+const CustomBox = ({ size = 50, ...props }: ComponentProps<typeof Box> & { size?: number }) => {
     return (
-        <div
-            style={{
-                backgroundColor: vars.color.background.primary,
-                width: size,
-                height: size,
-                border: '1px solid white',
-                textAlign: 'center',
-                alignContent: 'center',
-                color: 'white',
-                ...style,
-            }}
+        <Box
+            backgroundColor="$primary"
+            width={`${size}px`}
+            height={`${size}px`}
+            border="1px solid white"
+            textAlign="center"
+            alignContent="center"
+            color="white"
             {...props}
         />
     );

--- a/packages/core/src/components/h-stack/h-stack.tsx
+++ b/packages/core/src/components/h-stack/h-stack.tsx
@@ -12,15 +12,11 @@ type HStackPrimitiveProps = ComponentPropsWithoutRef<typeof Flex>;
 
 interface HStackProps extends HStackPrimitiveProps, HStackVariants {}
 
-const HStack = forwardRef<HTMLDivElement, HStackProps>(({ style, children, ...props }, ref) => {
+const HStack = forwardRef<HTMLDivElement, HStackProps>(({ children, ...props }, ref) => {
     const [hStackProps, otherProps] = createSplitProps<HStackVariants>()(props, ['reverse']);
 
     return (
-        <Flex
-            style={{ flexDirection: hStackProps.reverse ? 'row-reverse' : 'row', ...style }}
-            ref={ref}
-            {...otherProps}
-        >
+        <Flex flexDirection={hStackProps.reverse ? 'row-reverse' : 'row'} ref={ref} {...otherProps}>
             {children}
         </Flex>
     );

--- a/packages/core/src/components/switch/switch.stories.tsx
+++ b/packages/core/src/components/switch/switch.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
 export const TestBed: Story = {
     render: () => {
         return (
-            <VStack style={{ gap: 'var(--vapor-size-dimension-150)' }}>
+            <VStack gap="$150">
                 <Switch.Root size="sm">
                     <Switch.Control />
                     <Switch.Label>Test Bed</Switch.Label>

--- a/packages/core/src/components/text-input/text-input.stories.tsx
+++ b/packages/core/src/components/text-input/text-input.stories.tsx
@@ -50,13 +50,7 @@ export const Controlled: Story = {
 
 export const TestBed: Story = {
     render: (args) => (
-        <Grid.Root
-            templateRows="repeat(3, 1fr)"
-            templateColumns="repeat(3, 1fr)"
-            style={{
-                gap: 'var(--vapor-size-dimension-300)',
-            }}
-        >
+        <Grid.Root templateRows="repeat(3, 1fr)" templateColumns="repeat(3, 1fr)" gap="$300">
             <TextInput.Root placeholder="sadf" {...args}>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />

--- a/packages/core/src/components/text/text.stories.tsx
+++ b/packages/core/src/components/text/text.stories.tsx
@@ -59,7 +59,7 @@ const PANGRAM = 'Bright vixens jump; dozy fowl quack.';
 export const Default: StoryObj<typeof Text> = {
     render: (args) => {
         return (
-            <VStack style={{ gap: 'var(--vapor-size-dimension-300)' }}>
+            <VStack gap="$300">
                 <Text typography="code2" {...args}>
                     {PANGRAM}
                 </Text>
@@ -116,7 +116,7 @@ export const Default: StoryObj<typeof Text> = {
 export const TestBed: StoryObj<typeof Text> = {
     render: () => {
         return (
-            <VStack style={{ gap: 'var(--vapor-size-dimension-050)' }}>
+            <VStack gap="$050">
                 <Text typography="code2">{PANGRAM}</Text>
                 <Text typography="code1">{PANGRAM}</Text>
 

--- a/packages/core/src/components/v-stack/v-stack.stories.tsx
+++ b/packages/core/src/components/v-stack/v-stack.stories.tsx
@@ -5,6 +5,7 @@ import type { StoryObj } from '@storybook/react';
 import { vars } from '~/styles/vars.css';
 
 import { VStack } from '.';
+import { Box } from '../box';
 
 export default {
     title: 'VStack',
@@ -27,11 +28,11 @@ export const Default: StoryObj<typeof VStack> = {
     render: (args) => {
         return (
             <VStack {...args}>
-                <Box size={90}>1</Box>
-                <Box size={80}>2</Box>
-                <Box size={70}>3</Box>
-                <Box size={60}>4</Box>
-                <Box size={50}>5</Box>
+                <CustomBox size={90}>1</CustomBox>
+                <CustomBox size={80}>2</CustomBox>
+                <CustomBox size={70}>3</CustomBox>
+                <CustomBox size={60}>4</CustomBox>
+                <CustomBox size={50}>5</CustomBox>
             </VStack>
         );
     },
@@ -41,29 +42,26 @@ export const TestBed: StoryObj<typeof VStack> = {
     render: (args) => {
         return (
             <VStack {...args}>
-                <Box size={90}>1</Box>
-                <Box size={80}>2</Box>
-                <Box size={70}>3</Box>
-                <Box size={60}>4</Box>
-                <Box size={50}>5</Box>
+                <CustomBox size={90}>1</CustomBox>
+                <CustomBox size={80}>2</CustomBox>
+                <CustomBox size={70}>3</CustomBox>
+                <CustomBox size={60}>4</CustomBox>
+                <CustomBox size={50}>5</CustomBox>
             </VStack>
         );
     },
 };
 
-const Box = ({ size = 50, style, ...props }: ComponentProps<'div'> & { size?: number }) => {
+const CustomBox = ({ size = 50, ...props }: ComponentProps<typeof Box> & { size?: number }) => {
     return (
-        <div
-            style={{
-                backgroundColor: vars.color.background.primary,
-                width: size,
-                height: size,
-                border: '1px solid white',
-                textAlign: 'center',
-                alignContent: 'center',
-                color: 'white',
-                ...style,
-            }}
+        <Box
+            backgroundColor="$primary"
+            width={`${size}px`}
+            height={`${size}px`}
+            border="1px solid white"
+            textAlign="center"
+            alignContent="center"
+            color="white"
             {...props}
         />
     );

--- a/packages/core/src/components/v-stack/v-stack.tsx
+++ b/packages/core/src/components/v-stack/v-stack.tsx
@@ -12,13 +12,13 @@ type VStackPrimitiveProps = ComponentPropsWithoutRef<typeof Flex>;
 
 interface VStackProps extends VStackPrimitiveProps, VStackVariants {}
 
-const VStack = forwardRef<HTMLDivElement, VStackProps>(({ style, children, ...props }, ref) => {
+const VStack = forwardRef<HTMLDivElement, VStackProps>(({ children, ...props }, ref) => {
     const [vStackProps, otherProps] = createSplitProps<VStackVariants>()(props, ['reverse']);
 
     return (
         <Flex
             ref={ref}
-            style={{ flexDirection: vStackProps.reverse ? 'column-reverse' : 'column', ...style }}
+            flexDirection={vStackProps.reverse ? 'column-reverse' : 'column'}
             {...otherProps}
         >
             {children}

--- a/packages/core/src/styles/sprinkles.css.ts
+++ b/packages/core/src/styles/sprinkles.css.ts
@@ -25,46 +25,162 @@ const dimensionTokens = vars.size.dimension;
 const radiusTokens = vars.size.borderRadius;
 const { foreground, black, white, logo, ...colors } = vars.color;
 
-// function overload #1
-function spreadColorTokens<ColorTokens extends Record<string, string>>(
-    colorTokens: ColorTokens,
-    colorName: '',
-): Record<keyof ColorTokens & string, string>;
-
-// function overload #2
-function spreadColorTokens<ColorTokens extends Record<string, string>, ColorName extends string>(
-    colorTokens: ColorTokens,
-    colorName: ColorName,
-): Record<`${ColorName}-${keyof ColorTokens & string}`, string>;
-
-// function implementation
-function spreadColorTokens<ColorTokens extends Record<string, string>, ColorName extends string>(
-    colorTokens: ColorTokens,
-    colorName: ColorName,
-): Record<string, string> {
-    return Object.entries(colorTokens).reduce(
-        (acc, [shade, value]) => {
-            const key = colorName ? `${colorName}-${shade}` : shade;
-            acc[key] = value;
-            return acc;
-        },
-        {} as Record<string, string>,
-    );
-}
-
 const colorTokens = {
-    ...spreadColorTokens(colors.background, ''),
-    ...spreadColorTokens(colors.blue, 'blue'),
-    ...spreadColorTokens(colors.cyan, 'cyan'),
-    ...spreadColorTokens(colors.grape, 'grape'),
-    ...spreadColorTokens(colors.gray, 'gray'),
-    ...spreadColorTokens(colors.green, 'green'),
-    ...spreadColorTokens(colors.lime, 'lime'),
-    ...spreadColorTokens(colors.orange, 'orange'),
-    ...spreadColorTokens(colors.pink, 'pink'),
-    ...spreadColorTokens(colors.red, 'red'),
-    ...spreadColorTokens(colors.violet, 'violet'),
-    ...spreadColorTokens(colors.yellow, 'yellow'),
+    // Background colors (no prefix)
+    'rgb-primary': colors.background['rgb-primary'],
+    primary: colors.background.primary,
+    'rgb-secondary': colors.background['rgb-secondary'],
+    secondary: colors.background.secondary,
+    'rgb-success': colors.background['rgb-success'],
+    success: colors.background.success,
+    'rgb-warning': colors.background['rgb-warning'],
+    warning: colors.background.warning,
+    'rgb-danger': colors.background['rgb-danger'],
+    danger: colors.background.danger,
+    'rgb-hint': colors.background['rgb-hint'],
+    hint: colors.background.hint,
+    'rgb-contrast': colors.background['rgb-contrast'],
+    contrast: colors.background.contrast,
+    'rgb-normal': colors.background['rgb-normal'],
+    normal: colors.background.normal,
+    'normal-lighter': colors.background['normal-lighter'],
+    'normal-darker': colors.background['normal-darker'],
+
+    // Blue colors with prefix
+    'blue-050': colors.blue['050'],
+    'blue-100': colors.blue['100'],
+    'blue-200': colors.blue['200'],
+    'blue-300': colors.blue['300'],
+    'blue-400': colors.blue['400'],
+    'blue-500': colors.blue['500'],
+    'blue-600': colors.blue['600'],
+    'blue-700': colors.blue['700'],
+    'blue-800': colors.blue['800'],
+    'blue-900': colors.blue['900'],
+
+    // Cyan colors with prefix
+    'cyan-050': colors.cyan['050'],
+    'cyan-100': colors.cyan['100'],
+    'cyan-200': colors.cyan['200'],
+    'cyan-300': colors.cyan['300'],
+    'cyan-400': colors.cyan['400'],
+    'cyan-500': colors.cyan['500'],
+    'cyan-600': colors.cyan['600'],
+    'cyan-700': colors.cyan['700'],
+    'cyan-800': colors.cyan['800'],
+    'cyan-900': colors.cyan['900'],
+
+    // Grape colors with prefix
+    'grape-050': colors.grape['050'],
+    'grape-100': colors.grape['100'],
+    'grape-200': colors.grape['200'],
+    'grape-300': colors.grape['300'],
+    'grape-400': colors.grape['400'],
+    'grape-500': colors.grape['500'],
+    'grape-600': colors.grape['600'],
+    'grape-700': colors.grape['700'],
+    'grape-800': colors.grape['800'],
+    'grape-900': colors.grape['900'],
+
+    // Gray colors with prefix
+    'gray-000': colors.gray['000'],
+    'gray-050': colors.gray['050'],
+    'gray-100': colors.gray['100'],
+    'gray-200': colors.gray['200'],
+    'gray-300': colors.gray['300'],
+    'gray-400': colors.gray['400'],
+    'gray-500': colors.gray['500'],
+    'gray-600': colors.gray['600'],
+    'gray-700': colors.gray['700'],
+    'gray-800': colors.gray['800'],
+    'gray-900': colors.gray['900'],
+    'gray-950': colors.gray['950'],
+
+    // Green colors with prefix
+    'green-050': colors.green['050'],
+    'green-100': colors.green['100'],
+    'green-200': colors.green['200'],
+    'green-300': colors.green['300'],
+    'green-400': colors.green['400'],
+    'green-500': colors.green['500'],
+    'green-600': colors.green['600'],
+    'green-700': colors.green['700'],
+    'green-800': colors.green['800'],
+    'green-900': colors.green['900'],
+
+    // Lime colors with prefix
+    'lime-050': colors.lime['050'],
+    'lime-100': colors.lime['100'],
+    'lime-200': colors.lime['200'],
+    'lime-300': colors.lime['300'],
+    'lime-400': colors.lime['400'],
+    'lime-500': colors.lime['500'],
+    'lime-600': colors.lime['600'],
+    'lime-700': colors.lime['700'],
+    'lime-800': colors.lime['800'],
+    'lime-900': colors.lime['900'],
+
+    // Orange colors with prefix
+    'orange-050': colors.orange['050'],
+    'orange-100': colors.orange['100'],
+    'orange-200': colors.orange['200'],
+    'orange-300': colors.orange['300'],
+    'orange-400': colors.orange['400'],
+    'orange-500': colors.orange['500'],
+    'orange-600': colors.orange['600'],
+    'orange-700': colors.orange['700'],
+    'orange-800': colors.orange['800'],
+    'orange-900': colors.orange['900'],
+
+    // Pink colors with prefix
+    'pink-050': colors.pink['050'],
+    'pink-100': colors.pink['100'],
+    'pink-200': colors.pink['200'],
+    'pink-300': colors.pink['300'],
+    'pink-400': colors.pink['400'],
+    'pink-500': colors.pink['500'],
+    'pink-600': colors.pink['600'],
+    'pink-700': colors.pink['700'],
+    'pink-800': colors.pink['800'],
+    'pink-900': colors.pink['900'],
+
+    // Red colors with prefix
+    'red-050': colors.red['050'],
+    'red-100': colors.red['100'],
+    'red-200': colors.red['200'],
+    'red-300': colors.red['300'],
+    'red-400': colors.red['400'],
+    'red-500': colors.red['500'],
+    'red-600': colors.red['600'],
+    'red-700': colors.red['700'],
+    'red-800': colors.red['800'],
+    'red-900': colors.red['900'],
+
+    // Violet colors with prefix
+    'violet-050': colors.violet['050'],
+    'violet-100': colors.violet['100'],
+    'violet-200': colors.violet['200'],
+    'violet-300': colors.violet['300'],
+    'violet-400': colors.violet['400'],
+    'violet-500': colors.violet['500'],
+    'violet-600': colors.violet['600'],
+    'violet-700': colors.violet['700'],
+    'violet-800': colors.violet['800'],
+    'violet-900': colors.violet['900'],
+
+    // Yellow colors with prefix
+    'yellow-050': colors.yellow['050'],
+    'yellow-100': colors.yellow['100'],
+    'yellow-200': colors.yellow['200'],
+    'yellow-300': colors.yellow['300'],
+    'yellow-400': colors.yellow['400'],
+    'yellow-500': colors.yellow['500'],
+    'yellow-600': colors.yellow['600'],
+    'yellow-700': colors.yellow['700'],
+    'yellow-800': colors.yellow['800'],
+    'yellow-900': colors.yellow['900'],
+
+    // Base colors
     black,
     white,
 };
@@ -82,6 +198,9 @@ const sprinkleProperties = defineProperties({
         justifyContent: true,
         flexDirection: true,
         gap: spaceTokens,
+
+        // Alignment
+        alignContent: true,
 
         // Spacing
         padding: spaceTokens,
@@ -107,7 +226,7 @@ const sprinkleProperties = defineProperties({
         border: true,
         borderRadius: radiusTokens,
         backgroundColor: colorTokens,
-        color: colorTokens,
+        color: foreground,
         opacity: true,
 
         // Behavior
@@ -125,24 +244,6 @@ const sprinkleProperties = defineProperties({
 });
 
 export const sprinkles = createRainbowSprinkles(sprinkleProperties);
-
-/**
- * Maps semantic property names to actual CSS properties
- * This allows for more intuitive prop names in components
- */
-export const customPropertyMap = {
-    foreground: 'color',
-    background: 'backgroundColor',
-} as const;
-
-type BaseSprinkleProps = Parameters<typeof sprinkles>[0];
-type CustomProperties = typeof customPropertyMap;
-type MappedPropertyKeys = CustomProperties[keyof CustomProperties];
-
-/**
- * Enhanced sprinkles type that includes custom semantic properties
- * while excluding the original mapped properties to avoid conflicts
- */
-export type Sprinkles = Omit<BaseSprinkleProps, MappedPropertyKeys> & {
-    [K in keyof CustomProperties]?: BaseSprinkleProps[CustomProperties[K]];
+export type Sprinkles = Omit<Parameters<typeof sprinkles>[0], 'color'> & {
+    foregroundColor?: `${keyof typeof foreground}`;
 };


### PR DESCRIPTION
- layout props 복구
- Box에만 기본적으로 추가해두었음
- 그리고 Grid, Flex, VStack, HStack는 Box를 사용하고 있기 때문에 마찬가지로 추가되어 있음
- 타입 추론이 불가능했던 이유는, backgroundColor, foregroundColor를 동적으로 생성하고 있기 때문이었음
- 그래서 정적으로 일일이 생성해주었음
- foregroundColor는 일단 제거해두었음. color라는 이름 대신 foregroundColor로 추가하고 싶었는데, 아직까지는 방법을 찾지 못했음