### PR TITLE
docs: update import order and include global CSS in layout

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,7 +6,7 @@ module.exports = {
     printWidth: 100,
 
     plugins: ['@trivago/prettier-plugin-sort-imports'],
-    importOrder: ['^react(.*)', '<THIRD_PARTY_MODULES>', '^[~/]', '^[./]'],
+    importOrder: ['./global.css', '^react(.*)', '<THIRD_PARTY_MODULES>', '^[~/]', '^[./]'],
     importOrderSeparation: true,
     importOrderSortSpecifiers: true,
 };

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import './global.css';
 import type { ReactNode } from 'react';
 
 import { ThemeProvider, ThemeScript } from '@vapor-ui/core';
@@ -9,7 +10,6 @@ import { usePathname } from 'next/navigation';
 
 import DefaultSearchDialog from '~/components/search/search';
 
-import './global.css';
 
 const inter = Inter({
     subsets: ['latin'],


### PR DESCRIPTION
This pull request introduces changes to the import order configuration in `.prettierrc.js` and adjusts the import of `./global.css` in `layout.tsx` to align with the updated order. These changes aim to ensure consistent styling and adherence to the configured import order.

### Import Order Configuration:

* [`.prettierrc.js`](diffhunk://#diff-7312296367dd7c725b9beb500d7dab7bbeeb2aa03a1010a3fb2935f826d03fa6L9-R9): Updated the `importOrder` to prioritize `./global.css` at the top of imports, ensuring consistent placement of global styles.

### Import Adjustments:

* [`apps/website/src/app/layout.tsx`](diffhunk://#diff-d9c8dd9cba006bd0472a885a8f8f9ab9483b9fc5bb065a8cd4f6375e5db1a8cdR3): Moved the import of `./global.css` to the top of the file to comply with the new import order configuration. 