### PR TITLE
feat: Add Tailwind CSS v4 Support

### DIFF
--- a/.changeset/warm-pens-find.md
+++ b/.changeset/warm-pens-find.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': minor
+---
+
+feat: Add Tailwind CSS v4 Preset

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
             "import": "./dist/components/*/index.js",
             "require": "./dist/components/*/index.cjs"
         },
-        "./styles.css": "./dist/styles.css"
+        "./styles.css": "./dist/styles.css",
+        "./tailwind.css": "./dist/tailwind.css"
     },
     "files": [
         "dist"

--- a/packages/core/src/styles/tailwind-preset.css.ts
+++ b/packages/core/src/styles/tailwind-preset.css.ts
@@ -1,4 +1,3 @@
-import type { GlobalStyleRule } from '@vanilla-extract/css';
 import { globalStyle } from '@vanilla-extract/css';
 
 import {
@@ -15,7 +14,7 @@ import {
 import { vars } from './vars.css';
 
 /**
- * Tailwind CSS가 지원하는 테마 변수 네임스페이스를 타입으로 정의합니다.
+ * Define the theme variable namespace supported by Tailwind CSS as a type.
  * @see https://tailwindcss.com/docs/theme#theme-variable-namespaces
  */
 type TailwindThemeNamespace =
@@ -27,10 +26,6 @@ type TailwindThemeNamespace =
     | 'font-weight'
     | 'leading'
     | 'tracking';
-
-interface GlobalStyleRuleWithTheme extends GlobalStyleRule {
-    '@theme'?: Record<string, string>;
-}
 
 /* -------------------------------------------------------------------------------------------------
  * @theme layer
@@ -115,15 +110,10 @@ const otherThemeMaps = themeMappings.reduce<Record<string, string>>(
     {},
 );
 
-const themeStyle: GlobalStyleRuleWithTheme = {
-    '@theme': {
-        ...colorThemeMap,
-        ...otherThemeMaps,
-    },
-};
-
-globalStyle(':root', themeStyle);
-
+globalStyle('@theme', {
+    ...colorThemeMap,
+    ...otherThemeMaps,
+});
 /* -------------------------------------------------------------------------------------------------
  * @utility layer
  * -----------------------------------------------------------------------------------------------*/

--- a/packages/core/src/styles/tailwind-preset.css.ts
+++ b/packages/core/src/styles/tailwind-preset.css.ts
@@ -1,0 +1,70 @@
+import { createGlobalTheme, createGlobalThemeContract } from '@vanilla-extract/css';
+
+import { vars } from './vars.css';
+
+const tailwindContract = createGlobalThemeContract(
+    {
+        color: {
+            vapor: vars.color,
+        },
+        font: {
+            vapor: vars.typography.fontFamily,
+        },
+        text: {
+            vapor: vars.typography.fontSize,
+        },
+        'font-weight': {
+            vapor: vars.typography.fontWeight,
+        },
+        tracking: {
+            vapor: vars.typography.letterSpacing,
+        },
+        leading: {
+            vapor: vars.typography.lineHeight,
+        },
+        spacing: {
+            vapor: {
+                ...vars.size.space,
+                ...vars.size.dimension,
+            },
+        },
+        radius: {
+            vapor: vars.size.borderRadius,
+        },
+    },
+    (value, path) => {
+        return `${path.join('-')}`;
+    },
+);
+
+const tokenMap = {
+    color: {
+        vapor: vars.color,
+    },
+    font: {
+        vapor: vars.typography.fontFamily,
+    },
+    text: {
+        vapor: vars.typography.fontSize,
+    },
+    'font-weight': {
+        vapor: vars.typography.fontWeight,
+    },
+    tracking: {
+        vapor: vars.typography.letterSpacing,
+    },
+    leading: {
+        vapor: vars.typography.lineHeight,
+    },
+    spacing: {
+        vapor: {
+            ...vars.size.space,
+            ...vars.size.dimension,
+        },
+    },
+    radius: {
+        vapor: vars.size.borderRadius,
+    },
+};
+
+createGlobalTheme('@theme', tailwindContract, tokenMap);

--- a/packages/core/src/styles/tailwind-preset.css.ts
+++ b/packages/core/src/styles/tailwind-preset.css.ts
@@ -1,70 +1,164 @@
-import { createGlobalTheme, createGlobalThemeContract } from '@vanilla-extract/css';
+import type { GlobalStyleRule } from '@vanilla-extract/css';
+import { globalStyle } from '@vanilla-extract/css';
 
+import {
+    BORDER_RADIUS,
+    FONT_FAMILY,
+    FONT_SIZE,
+    FONT_WEIGHT,
+    LETTER_SPACING,
+    LIGHT_BASIC_COLORS,
+    LIGHT_SEMANTIC_COLORS,
+    LINE_HEIGHT,
+    SPACE,
+} from './tokens';
 import { vars } from './vars.css';
 
-const tailwindContract = createGlobalThemeContract(
-    {
-        color: {
-            vapor: vars.color,
-        },
-        font: {
-            vapor: vars.typography.fontFamily,
-        },
-        text: {
-            vapor: vars.typography.fontSize,
-        },
-        'font-weight': {
-            vapor: vars.typography.fontWeight,
-        },
-        tracking: {
-            vapor: vars.typography.letterSpacing,
-        },
-        leading: {
-            vapor: vars.typography.lineHeight,
-        },
-        spacing: {
-            vapor: {
-                ...vars.size.space,
-                ...vars.size.dimension,
-            },
-        },
-        radius: {
-            vapor: vars.size.borderRadius,
-        },
+/**
+ * Tailwind CSS가 지원하는 테마 변수 네임스페이스를 타입으로 정의합니다.
+ * @see https://tailwindcss.com/docs/theme#theme-variable-namespaces
+ */
+type TailwindThemeNamespace =
+    | 'color'
+    | 'spacing'
+    | 'radius'
+    | 'font'
+    | 'text'
+    | 'font-weight'
+    | 'leading'
+    | 'tracking';
+
+interface GlobalStyleRuleWithTheme extends GlobalStyleRule {
+    '@theme'?: Record<string, string>;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * @theme layer
+ * -----------------------------------------------------------------------------------------------*/
+
+// Basic Tokens - Colors
+const colorThemeMap = Object.entries(LIGHT_BASIC_COLORS).reduce<Record<string, string>>(
+    (acc, [colorName, colorScale]) => {
+        const contractColorGroup = vars.color[colorName as keyof typeof LIGHT_BASIC_COLORS];
+
+        if (typeof colorScale === 'object' && colorScale !== null && contractColorGroup) {
+            for (const shade in colorScale) {
+                if (Object.prototype.hasOwnProperty.call(colorScale, shade)) {
+                    const transformedShade = shade.replace(/^0+/, '') || '0';
+                    const targetVarName = `--color-v-${colorName}-${transformedShade}`;
+                    const sourceVar = (contractColorGroup as Record<string, string>)[shade];
+                    acc[targetVarName] = String(sourceVar);
+                }
+            }
+        } else {
+            const targetVarName = `--color-v-${colorName}`;
+            acc[targetVarName] = String(contractColorGroup);
+        }
+        return acc;
     },
-    (value, path) => {
-        return `${path.join('-')}`;
-    },
+    {},
 );
 
-const tokenMap = {
-    color: {
-        vapor: vars.color,
+// Basic Tokens - Size, Typography
+const themeMappings: {
+    namespace: TailwindThemeNamespace;
+    tokenObject: Record<string, unknown>;
+    contractBranch: Record<string, string>;
+    keyTransformer?: (key: string) => string;
+}[] = [
+    { namespace: 'spacing', tokenObject: SPACE, contractBranch: vars.size.space },
+    { namespace: 'radius', tokenObject: BORDER_RADIUS, contractBranch: vars.size.borderRadius },
+    {
+        namespace: 'font',
+        tokenObject: FONT_FAMILY,
+        contractBranch: vars.typography.fontFamily,
+        keyTransformer: (k) => k,
     },
-    font: {
-        vapor: vars.typography.fontFamily,
+    {
+        namespace: 'text',
+        tokenObject: FONT_SIZE,
+        contractBranch: vars.typography.fontSize,
+        keyTransformer: (k) => k.replace(/^0+/, ''),
     },
-    text: {
-        vapor: vars.typography.fontSize,
+    {
+        namespace: 'font-weight',
+        tokenObject: FONT_WEIGHT,
+        contractBranch: vars.typography.fontWeight,
+        keyTransformer: (k) => k,
     },
-    'font-weight': {
-        vapor: vars.typography.fontWeight,
+    {
+        namespace: 'leading',
+        tokenObject: LINE_HEIGHT,
+        contractBranch: vars.typography.lineHeight,
+        keyTransformer: (k) => k.replace(/^0+/, ''),
     },
-    tracking: {
-        vapor: vars.typography.letterSpacing,
+    {
+        namespace: 'tracking',
+        tokenObject: LETTER_SPACING,
+        contractBranch: vars.typography.letterSpacing,
     },
-    leading: {
-        vapor: vars.typography.lineHeight,
+];
+const otherThemeMaps = themeMappings.reduce<Record<string, string>>(
+    (acc, { namespace, tokenObject, contractBranch, keyTransformer }) => {
+        const defaultTransformer = (key: string) => key.replace(/^0+/, '') || '0';
+        const transformer = keyTransformer || defaultTransformer;
+
+        for (const key in tokenObject) {
+            if (Object.prototype.hasOwnProperty.call(tokenObject, key)) {
+                const transformedKey = transformer(key);
+                const newKey = `--${namespace}-v-${transformedKey}`;
+                acc[newKey] = String(contractBranch[key]);
+            }
+        }
+        return acc;
     },
-    spacing: {
-        vapor: {
-            ...vars.size.space,
-            ...vars.size.dimension,
-        },
-    },
-    radius: {
-        vapor: vars.size.borderRadius,
+    {},
+);
+
+const themeStyle: GlobalStyleRuleWithTheme = {
+    '@theme': {
+        ...colorThemeMap,
+        ...otherThemeMaps,
     },
 };
 
-createGlobalTheme('@theme', tailwindContract, tokenMap);
+globalStyle(':root', themeStyle);
+
+/* -------------------------------------------------------------------------------------------------
+ * @utility layer
+ * -----------------------------------------------------------------------------------------------*/
+const semanticMappings = [
+    {
+        prefix: 'bg',
+        property: 'backgroundColor',
+        contractGroup: 'background',
+        tokenGroup: LIGHT_SEMANTIC_COLORS.background,
+    },
+    {
+        prefix: 'text',
+        property: 'color',
+        contractGroup: 'foreground',
+        tokenGroup: LIGHT_SEMANTIC_COLORS.foreground,
+    },
+    {
+        prefix: 'border',
+        property: 'borderColor',
+        contractGroup: 'border',
+        tokenGroup: LIGHT_SEMANTIC_COLORS.border,
+    },
+] as const;
+
+semanticMappings.forEach(({ prefix, property, contractGroup, tokenGroup }) => {
+    const contractSemanticGroup = vars.color[contractGroup];
+    for (const name in tokenGroup) {
+        if (Object.prototype.hasOwnProperty.call(tokenGroup, name)) {
+            globalStyle(`@utility ${prefix}-v-${name}`, {
+                [property]: (contractSemanticGroup as Record<string, string>)[name],
+            });
+        }
+    }
+});
+
+globalStyle('@utility text-v-logo', {
+    color: vars.color.logo.normal,
+});

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -115,6 +115,8 @@ export default defineConfig([
             css: '@layer vapor-theme, vapor-reset, vapor-component, vapor-utilities;',
         },
     },
+
+    // Types build
     {
         entry: ['src/index.ts', 'src/components/*/index.ts'],
         outDir: DIR,
@@ -129,6 +131,7 @@ export default defineConfig([
     {
         entry: {
             styles: 'src/styles/index.ts',
+            tailwind: 'src/styles/tailwind-preset.css.ts',
         },
         outDir: DIR,
         esbuildPlugins: [


### PR DESCRIPTION
<details>
<summary><strong>한국어</strong></summary>

## 한국어 버전

### 개요
@vapor-ui/core가 Tailwind CSS v4를 공식적으로 지원하도록 기능을 추가합니다.

이번 변경을 통해, 개발자는 @vapor-ui/core의 모든 디자인 토큰을 `v-` 접두사가 붙은 Tailwind 유틸리티 클래스로 직접 사용할 수 있습니다.

### 주요 변경 사항

#### 1. CSS-first 접근 방식 채택
Tailwind CSS v4부터는 `tailwind.config.js` 파일을 통한 설정보다, CSS의 `@theme`과 `@layer`를 사용하는 CSS-first 방식을 공식적으로 권장하고 있습니다.

이에 따라, 별도의 JS 설정을 요구하는 대신 사용자가 CSS 파일을 임포트하는 것만으로 모든 기능이 동작하도록 구현했습니다. `dist/tailwind.css` 파일 내에 `@theme`과 `@utility` 규칙을 사용하여 모든 토큰 매핑과 유틸리티 클래스 생성을 처리합니다.

이 과정에서 [Tailwind 공식 문서에 정의된 테마 변수 네임스페이스](https://tailwindcss.com/docs/theme#theme-variable-namespaces)(`--color-*`, `--spacing-*` 등)를 준수했습니다. 이 규칙을 지켜야만 Tailwind 엔진이 변수를 올바르게 인식하고 `bg-*`, `p-*` 와 같은 유틸리티 클래스를 자동으로 생성할 수 있기 때문입니다.

#### 2. `@theme`과 `@utility` 역할 분리

의도치 않은 유틸리티 클래스가 생성되는 사이드 이펙트를 막기 위해 `@theme`과 `@utility`의 역할을 분리했습니다.

예를 들어, 시맨틱 토큰인 `--color-text-danger`를 `@theme`에 정의하면 다음과 같은 문제가 발생합니다.

- `bg-text-danger`
- `border-text-danger`

이를 해결하기 위해 역할을 명확히 분리했습니다.

| 규칙 | 역할 | 예시 | 결과 |
|------|------|------|------|
| `@theme` | 순수 값(Value) 토큰 정의 | `red-500`, `spacing-100` | 예측 가능한 클래스 생성 (`bg-red-500`) |
| `@utility` | 특정 목적의 시맨틱 클래스 정의 | `text-v-danger` | color 속성에만 한정된 클래스 생성 |

#### 3. `-v` 접두사(Prefix) 도입
모든 유틸리티 클래스에 `-v` 접두사를 추가했습니다. (예: `text-v-primary`, `p-v-100`)
이는 사용자가 클래스를 사용할 때 발생할 수 있는 혼란을 방지하기 위함입니다.

- `text-red-500`: 순수한 Tailwind 기본 토큰
- `text-v-red-500`: @vapor-ui/core의 red-500 토큰 (Vapor-exclusive)

이러한 명시적인 구분은, 특히 기존 Tailwind 프로젝트에 @vapor-ui/core를 도입하거나, 기본 테마를 일부 덮어쓸 때 어떤 토큰을 사용하고 있는지 명확하게 인지할 수 있도록 돕습니다. 이는 디자인 시스템 컴포넌트에 접두사를 붙이는 일반적인 모범 사례와도 일치합니다.

### 사용 방법

#### 1. CSS 설정
메인 CSS 파일에 @vapor-ui/core 스타일시트를 올바른 순서로 임포트합니다.

```css
/* styles/global.css */

@import "tailwindcss";
@import "@vapor-ui/core/styles.css";
@import "@vapor-ui/core/tailwind.css";
```

#### 2. TSX 예제

**Before (인라인 스타일 사용):**

```tsx
import { Button, Avatar } from "@vapor-ui/core";

const ProfileCardBefore = () => (
  <div style={{
    padding: 'var(--vapor-size-space-400)',
    borderRadius: 'var(--vapor-size-borderRadius-400)',
    backgroundColor: 'var(--vapor-color-background-secondary)',
    boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
    maxWidth: '320px'
  }}>
    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--vapor-size-space-300)' }}>
      <Avatar src="/avatar.png" />
      <div>
        <h3 style={{
          fontSize: 'var(--vapor-typography-fontSize-300)',
          fontWeight: 'var(--vapor-typography-fontWeight-700)',
          color: 'var(--vapor-color-foreground-primary)'
        }}>
          Vapor
        </h3>
        <p style={{
          fontSize: 'var(--vapor-typography-fontSize-100)',
          color: 'var(--vapor-color-foreground-secondary)'
        }}>
          UI
        </p>
      </div>
    </div>
    <Button style={{ marginTop: 'var(--vapor-size-space-300)', width: '100%' }}>
      Follow
    </Button>
  </div>
);
```

**After (Tailwind 유틸리티 클래스 사용):**

```tsx
import { Button, Avatar } from "@vapor-ui/core";

const ProfileCardAfter = () => (
  <div className="p-v-400 rounded-v-400 bg-v-secondary shadow-lg max-w-xs">
    <div className="flex items-center gap-v-300">
      <Avatar src="/avatar.png" />
      <div>
        <h3 className="text-v-300 font-weight-v-700 text-v-primary">
          Vapor
        </h3>
        <p className="text-v-100 text-v-secondary">
          UI
        </p>
      </div>
    </div>
    {/* 컴포넌트 스타일을 덮어쓰거나 상태(state)를 추가할 수도 있습니다. */}
    <Button className="mt-v-300 w-full bg-v-danger hover:bg-v-danger-darker">
      Follow
    </Button>
  </div>
);
```

### Known Issues

- @vapor-ui/core는 `@vapor-theme`, `@vapor-components`와 같은 내부적인 CSS 레이어(Layer)를 사용합니다. 
- 현재 사용자는 Tailwind CSS의 레이어와 @vapor-ui/core의 레이어 간의 우선순위를 직접 설정해야 할 수 있습니다.

이 문제는 별도의 PR에서 Vite, Next.js, Webpack 플러그인을 추가하여, 사용자의 설정 없이도 레이어 우선순위가 자동으로 올바르게 주입되도록 개선할 예정입니다.

</details>

<br/>


## Overview
This adds official support for Tailwind CSS v4 to @vapor-ui/core.

With this change, developers can use all of @vapor-ui/core's design tokens as Tailwind utility classes with a `v-` prefix, combining a consistent design system with a rapid development experience.

## Key Changes

### 1. Adopting a CSS-first Approach
Following Tailwind CSS v4's official recommendation, we've adopted a CSS-first approach using `@theme` and `@layer` instead of relying on a `tailwind.config.js` file.

This allows for a zero-config setup where users only need to import the provided CSS file. In this process, we have strictly adhered to the theme variable namespaces (`--color-*`, `--spacing-*`, etc.) defined in the official Tailwind documentation to ensure utility classes like `bg-*` and `p-*` are generated correctly.

### 2. Separating @theme and @utility Roles
We separated the roles of `@theme` and `@utility` to prevent side effects from unintended utility class generation.

For example, defining a semantic token like `--color-text-danger` within `@theme` would cause Tailwind to generate unwanted classes like `bg-text-danger` and `border-text-danger` due to the `--color-*` namespace rule.

To solve this, we've separated their roles:

- **@theme**: Defines only Basic Tokens (e.g., `color-red-500`, `size-spacing-100`) to generate predictable utility classes.
- **@utility**: Defines Semantic Tokens (e.g., `color-primary`) for specific purposes, ensuring they are only applied to the intended properties.

### 3. Introducing the -v Prefix
All utility classes have been prefixed with `-v` (e.g., `text-v-primary`, `p-v-100`) to prevent confusion.

- `text-red-500`: A pure, default Tailwind token.
- `text-v-red-500`: A @vapor-ui/core exclusive token.

This explicit distinction helps users clearly identify which token system is being used, especially when introducing @vapor-ui/core into an existing Tailwind project or overriding default themes. This aligns with common best practices for prefixing design system components.

## How to Use

### 1. CSS Setup
Import the @vapor-ui/core stylesheets into your main CSS file in the correct order.

```css
/* styles/global.css */

@import "tailwindcss";
@import "@vapor-ui/core/styles.css";
@import "@vapor-ui/core/tailwind.css";
```

### 2. TSX Example
The new utility classes allow you to rapidly build UIs that are consistent with the design system, combining @vapor-ui/core tokens with standard Tailwind utilities.

Here is a "Before" and "After" example of building a profile card:

**Before (with inline styles):**

```tsx
import { Button, Avatar } from "@vapor-ui/core";

const ProfileCardBefore = () => (
  <div style={{
    padding: 'var(--vapor-size-space-400)',
    borderRadius: 'var(--vapor-size-borderRadius-400)',
    backgroundColor: 'var(--vapor-color-background-secondary)',
    boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
    maxWidth: '320px'
  }}>
    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--vapor-size-space-300)' }}>
      <Avatar src="/avatar.png" />
      <div>
        <h3 style={{
          fontSize: 'var(--vapor-typography-fontSize-300)',
          fontWeight: 'var(--vapor-typography-fontWeight-700)',
          color: 'var(--vapor-color-foreground-primary)'
        }}>
          Vapor
        </h3>
        <p style={{
          fontSize: 'var(--vapor-typography-fontSize-100)',
          color: 'var(--vapor-color-foreground-secondary)'
        }}>
          UI Engineer
        </p>
      </div>
    </div>
    <Button style={{ marginTop: 'var(--vapor-size-space-300)', width: '100%' }}>
      Follow
    </Button>
  </div>
);
```

**After (with Tailwind utility classes):**

```tsx
import { Button, Avatar } from "@vapor-ui/core";

const ProfileCardAfter = () => (
  <div className="p-v-400 rounded-v-400 bg-v-secondary shadow-lg max-w-xs">
    <div className="flex items-center gap-v-300">
      <Avatar src="/avatar.png" />
      <div>
        <h3 className="text-v-300 font-weight-v-700 text-v-primary">
          Vapor
        </h3>
        <p className="text-v-100 text-v-secondary">
          UI Engineer
        </p>
      </div>
    </div>
    {/* You can also override component styles and add states */}
    <Button className="mt-v-300 w-full bg-v-danger hover:bg-v-danger-darker">
      Follow
    </Button>
  </div>
);
```

## Known Issues

- @vapor-ui/core uses internal CSS layers such as `@vapor-theme` and `@vapor-components`.
- Currently, users may need to manually set the prioritization between layers in Tailwind CSS and layers in @vapor-ui/core.

We'll be fixing this in a separate PR, adding Vite, Next.js, and Webpack plugins so that layer priorities are automatically injected correctly without any configuration from the user.

Translated with DeepL.com (free version)

## Screenshots
<img width="473" height="516" alt="스크린샷 2025-07-14 18 57 38" src="https://github.com/user-attachments/assets/40adff5a-17a0-4e8c-8598-47e3d15c5e12" />


<img width="509" height="542" alt="스크린샷 2025-07-14 18 58 43" src="https://github.com/user-attachments/assets/3ae9aea0-569f-48a2-961b-071736ac86cd" />
