### PR TITLE
docs(readme): fix document site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Vapor is a React-based UI library designed with a focus on accessibility, custom
 
 ## Documentation
 
-- **[Usage](https://vapor.goorm.io/docs/overview/installation)**: Learn how to install and configure the library.
+- **[Usage](https://vapor-ui.goorm.io/docs/getting-started/installation)**: Learn how to install and configure the library.
 - **[Contributing](https://github.com/goorm-dev/vapor-ui/blob/main/CONTRIBUTING.md)**: Guidelines for contributing to the project and local setup instructions.
 - **[Releases](https://github.com/goorm-dev/vapor-ui/releases)**: View changes for each version.
 
@@ -31,7 +31,7 @@ To install Vapor UI in your project, use the following command:
 npm i @vapor-ui/core @vapor-ui/icons @vapor-ui/hooks
 ```
 
-For detailed usage instructions, please refer to the [official documentation](https://vapor.goorm.io/docs/overview/installation).
+For detailed usage instructions, please refer to the [official documentation](https://vapor-ui.goorm.io/docs/getting-started/installation).
 
 ## Core Principles
 


### PR DESCRIPTION
This pull request updates the links in the `README.md` file to reflect changes in the documentation structure for Vapor UI. The updates ensure that users are directed to the correct sections of the official documentation.

### Documentation Updates:
* Updated the "Usage" link to point to the new "Getting Started" section in the official documentation (`https://vapor-ui.goorm.io/docs/getting-started/installation`) for both the overview and detailed usage instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)