### PR TITLE
refactor(build): Improve DX by Overhauling CSS Bundling Strategy

### DIFF
--- a/.changeset/giant-walls-switch.md
+++ b/.changeset/giant-walls-switch.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': minor
+---
+
+refactor(build): Improve DX by Overhauling CSS Bundling Strategy

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -11,3 +11,18 @@ import './sprinkles.css';
 import './theme.css';
 // 3. Create CSS variable contract
 import './vars.css';
+
+
+import '../components/avatar/avatar.css';
+import '../components/badge/badge.css';
+import '../components/button/button.css';
+import '../components/callout/callout.css';
+import '../components/card/card.css';
+import '../components/checkbox/checkbox.css';
+import '../components/dialog/dialog.css';
+import '../components/grid/grid.css';
+import '../components/icon-button/icon-button.css';
+import '../components/nav/nav.css';
+import '../components/radio-group/radio-group.css';
+import '../components/switch/switch.css';
+import '../components/text-input/text-input.css';


### PR DESCRIPTION
# Background

The existing build script used a method of dynamically injecting `import "./index.css"` statements into each component's JavaScript file. While this approach theoretically enabled **CSS tree-shaking**, it caused serious usability issues:

- CSS `@layer` priority issues: As components were dynamically imported, CSS injection order wasn't guaranteed, causing our designed `@layer` hierarchy (e.g., `reset`, `theme`, `component`) to break.
- High configuration barrier and learning curve: To resolve this issue, users were forced to implement complex additional configurations:
  1. Setting up separate PostCSS plugins like `postcss-import` or Vite plugins
  2. Manually declaring `@layer` order at the top of files like `globals.css`
  3. Ensuring `globals.css` is imported before any other components at the project's entry point

This approach violated the core principle of our design system: **"Easy to use with minimal configuration"**.

# Changes

Prioritizing user experience, we made the strategic decision to abandon CSS tree-shaking in favor of configuration simplicity. This is a proven approach adopted by major open-source libraries like Mantine and Radix Themes.

- AS-IS: During component build, inject CSS file import code into each component's JS file.
- TO-BE:
  1. First build all individual component CSS files (`dist/components/*/index.css`).
  2. After build completion, collect all generated CSS paths and aggregate them into the main stylesheet (`dist/styles.css`) using `@import` rules.
  3. Users now only need to import a single line: `@import "@vapor-ui/core/styles.css";` to properly apply all component styles and `@layer` rules.

To achieve this, we added explicit build order guarantee logic using `Promise` in `tsup.config.ts`, ensuring style aggregation only executes after component CSS generation is complete.

# Future Plans

For advanced users who require CSS tree-shaking, we plan to provide separate Vite or PostCSS plugins in the future, offering opt-in tree-shaking activation through guidelines. This will satisfy the requirements of both basic and advanced users.