### PR TITLE
feat: add radio-group unit test

### DIFF
--- a/.changeset/brown-hats-shave.md
+++ b/.changeset/brown-hats-shave.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+fix: remove incorrectly injected props

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -11,13 +11,13 @@ const OPTION_2 = 'Option 2';
 const RadioGroupTest = (props: RadioGroupRootProps) => {
     return (
         <RadioGroup.Root {...props}>
-            <RadioGroup.Item value="option1" data-testid="option1-item">
-                <RadioGroup.Control data-testid="option1-control" />
-                <RadioGroup.Label data-testid="option1-label">{OPTION_1}</RadioGroup.Label>
+            <RadioGroup.Item value="option1">
+                <RadioGroup.Control />
+                <RadioGroup.Label>{OPTION_1}</RadioGroup.Label>
             </RadioGroup.Item>
-            <RadioGroup.Item value="option2" data-testid="option2-item">
-                <RadioGroup.Control data-testid="option2-control" />
-                <RadioGroup.Label data-testid="option2-label">{OPTION_2}</RadioGroup.Label>
+            <RadioGroup.Item value="option2">
+                <RadioGroup.Control />
+                <RadioGroup.Label>{OPTION_2}</RadioGroup.Label>
             </RadioGroup.Item>
         </RadioGroup.Root>
     );
@@ -45,7 +45,7 @@ describe('RadioGroup', () => {
     it('should invoke onValueChange when an label is clicked', async () => {
         const onValueChange = vi.fn();
         const rendered = render(<RadioGroupTest onValueChange={onValueChange} />);
-        const item = rendered.getByTestId('option1-label');
+        const item = rendered.getByText(OPTION_1);
 
         await userEvent.click(item);
 
@@ -145,14 +145,12 @@ describe('RadioGroup', () => {
                     </RadioGroup.Item>
                 </RadioGroup.Root>
 
-                <button type="submit" data-testid="submit">
-                    Submit
-                </button>
+                <button type="submit">Submit</button>
             </form>,
         );
 
         const [radioA] = rendered.getAllByRole('radio');
-        const submitButton = rendered.getByTestId('submit');
+        const submitButton = rendered.getByRole('button', { name: 'Submit' });
 
         await userEvent.click(submitButton);
 
@@ -209,16 +207,15 @@ describe('RadioGroup', () => {
         const rendered = render(
             <RadioGroup.Root defaultValue="b">
                 <RadioGroup.Item value="a">
-                    <RadioGroup.Control data-testid="radio-a" />
+                    <RadioGroup.Control />
                 </RadioGroup.Item>
                 <RadioGroup.Item value="b">
-                    <RadioGroup.Control data-testid="radio-b" />
+                    <RadioGroup.Control />
                 </RadioGroup.Item>
             </RadioGroup.Root>,
         );
 
-        const radioA = rendered.getByTestId('radio-a');
-        const radioB = rendered.getByTestId('radio-b');
+        const [radioA, radioB] = rendered.getAllByRole('radio');
 
         await userEvent.tab();
 

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -1,0 +1,230 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'vitest-axe';
+
+import type { RadioGroupRootProps } from './radio-group';
+import { RadioGroup } from './radio-group';
+
+const OPTION_1 = 'Option 1';
+const OPTION_2 = 'Option 2';
+
+const RadioGroupTest = (props: RadioGroupRootProps) => {
+    return (
+        <RadioGroup.Root {...props}>
+            <RadioGroup.Item value="option1" data-testid="option1-item">
+                <RadioGroup.Control data-testid="option1-control" />
+                <RadioGroup.Label data-testid="option1-label">{OPTION_1}</RadioGroup.Label>
+            </RadioGroup.Item>
+            <RadioGroup.Item value="option2" data-testid="option2-item">
+                <RadioGroup.Control data-testid="option2-control" />
+                <RadioGroup.Label data-testid="option2-label">{OPTION_2}</RadioGroup.Label>
+            </RadioGroup.Item>
+        </RadioGroup.Root>
+    );
+};
+
+describe('RadioGroup', () => {
+    it('should have no a11y violations', async () => {
+        const rendered = render(<RadioGroupTest />);
+        const result = await axe(rendered.container);
+
+        expect(result).toHaveNoViolations();
+    });
+
+    it('should invoke onValueChange when an item is clicked', async () => {
+        const onValueChange = vi.fn();
+        const rendered = render(<RadioGroupTest onValueChange={onValueChange} />);
+        const [firstItem] = rendered.getAllByRole('radio');
+
+        await userEvent.click(firstItem);
+
+        expect(onValueChange).toHaveBeenCalledOnce();
+        expect(onValueChange).toHaveBeenCalledWith('option1');
+    });
+
+    it('should invoke onValueChange when an label is clicked', async () => {
+        const onValueChange = vi.fn();
+        const rendered = render(<RadioGroupTest onValueChange={onValueChange} />);
+        const item = rendered.getByTestId('option1-label');
+
+        await userEvent.click(item);
+
+        expect(onValueChange).toHaveBeenCalledOnce();
+        expect(onValueChange).toHaveBeenCalledWith('option1');
+    });
+
+    describe('prop: disabled', () => {
+        it('should not have aria-disabled attribute when not disabled', () => {
+            const rendered = render(<RadioGroupTest />);
+            const root = rendered.getByRole('radiogroup');
+
+            expect(root).not.toHaveAttribute('aria-disabled');
+            expect(root).not.toHaveAttribute('data-disabled');
+        });
+
+        it('should have aria-disabled attribute', () => {
+            const rendered = render(<RadioGroupTest disabled />);
+            const root = rendered.getByRole('radiogroup');
+            const [firstItem, secondItem] = rendered.getAllByRole('radio');
+
+            // the root component does not support the disabled attribute directly, so use aria-disabled attributes.
+            expect(root).toHaveAttribute('aria-disabled', 'true');
+            expect(root).toHaveAttribute('data-disabled');
+
+            expect(firstItem).toBeDisabled();
+            expect(firstItem).toHaveAttribute('data-disabled');
+            expect(secondItem).toBeDisabled();
+            expect(secondItem).toHaveAttribute('data-disabled');
+        });
+
+        it('should not invoke onValueChange when an item is clicked', async () => {
+            const onValueChange = vi.fn();
+            const rendered = render(<RadioGroupTest disabled onValueChange={onValueChange} />);
+            const [firstItem] = rendered.getAllByRole('radio');
+
+            await userEvent.click(firstItem);
+
+            expect(onValueChange).not.toHaveBeenCalled();
+        });
+
+        it('should not change its state when clicked', async () => {
+            const rendered = render(<RadioGroupTest disabled />);
+            const [firstItem] = rendered.getAllByRole('radio');
+
+            expect(firstItem).not.toBeChecked();
+            expect(firstItem).toHaveAttribute('aria-checked', 'false');
+
+            await userEvent.click(firstItem);
+
+            expect(firstItem).not.toBeChecked();
+            expect(firstItem).toHaveAttribute('aria-checked', 'false');
+        });
+    });
+
+    it('should propagate the name attribute to the input', () => {
+        const name = 'test-radio-group';
+        const rendered = render(
+            <form>
+                <RadioGroupTest name={name} />
+            </form>,
+        );
+
+        const group = rendered.getByRole('radiogroup');
+        const inputs = group.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+
+        inputs.forEach((input) => {
+            expect(input).toHaveAttribute('name', name);
+        });
+    });
+
+    it('should include the radio value in the form submission', async ({ skip }) => {
+        if (isJSDOM) {
+            // FormData is not available in JSDOM
+            skip();
+        }
+
+        let stringifiedFormData = '';
+
+        const rendered = render(
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+
+                    const formData = new FormData(e.currentTarget);
+                    stringifiedFormData = new URLSearchParams(formData as never).toString();
+                }}
+            >
+                <RadioGroup.Root name="radio-group-test">
+                    <RadioGroup.Item value="a">
+                        <RadioGroup.Label>a</RadioGroup.Label>
+                        <RadioGroup.Control />
+                    </RadioGroup.Item>
+                    <RadioGroup.Item value="b">
+                        <RadioGroup.Label>b</RadioGroup.Label>
+                        <RadioGroup.Control />
+                    </RadioGroup.Item>
+                </RadioGroup.Root>
+
+                <button type="submit" data-testid="submit">
+                    Submit
+                </button>
+            </form>,
+        );
+
+        const [radioA] = rendered.getAllByRole('radio');
+        const submitButton = rendered.getByTestId('submit');
+
+        await userEvent.click(submitButton);
+
+        expect(stringifiedFormData).toBe('');
+
+        await userEvent.click(radioA);
+        await userEvent.click(submitButton);
+
+        expect(stringifiedFormData).toBe('radio-group-test=a');
+    });
+
+    it('should automatically select radio upon navigation', async () => {
+        const rendered = render(<RadioGroupTest />);
+        const [firstItem, secondItem] = rendered.getAllByRole('radio');
+
+        firstItem.focus();
+
+        expect(firstItem).toHaveFocus();
+        expect(firstItem).not.toBeChecked();
+        expect(secondItem).not.toBeChecked();
+
+        await userEvent.keyboard('[ArrowDown]');
+
+        expect(secondItem).toHaveFocus();
+
+        /**
+         * Note:
+         * - When userEvent.keyboard([ArrowDown]) is input in the test environment, the checked state does not automatically change.
+         * - Therefore, userEvent.keyboard([Space]) has been temporarily added to manually toggle the state.
+         *
+         * @link https://github.com/radix-ui/primitives/issues/3076
+         */
+        await userEvent.keyboard('[Space]');
+
+        expect(firstItem).not.toBeChecked();
+        expect(secondItem).toBeChecked();
+    });
+
+    it('does not forward `value` prop', async () => {
+        const rendered = render(
+            <RadioGroup.Root value="test" data-testid="radio-group">
+                <RadioGroup.Item value="">
+                    <RadioGroup.Control />
+                </RadioGroup.Item>
+            </RadioGroup.Root>,
+        );
+
+        const root = rendered.getByTestId('radio-group');
+
+        expect(root).not.toHaveAttribute('value');
+    });
+
+    it('sets tabIndex=0 to the correct element when focused', async () => {
+        const rendered = render(
+            <RadioGroup.Root defaultValue="b">
+                <RadioGroup.Item value="a">
+                    <RadioGroup.Control data-testid="radio-a" />
+                </RadioGroup.Item>
+                <RadioGroup.Item value="b">
+                    <RadioGroup.Control data-testid="radio-b" />
+                </RadioGroup.Item>
+            </RadioGroup.Root>,
+        );
+
+        const radioA = rendered.getByTestId('radio-a');
+        const radioB = rendered.getByTestId('radio-b');
+
+        await userEvent.tab();
+
+        expect(radioA).toHaveAttribute('tabindex', '-1');
+        expect(radioB).toHaveAttribute('tabindex', '0');
+    });
+});
+
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -162,6 +162,85 @@ describe('RadioGroup', () => {
         expect(stringifiedFormData).toBe('radio-group-test=a');
     });
 
+    it('should change the checked state using the arrow keys', async () => {
+        const rendered = render(
+            <RadioGroup.Root>
+                <RadioGroup.Item value="option1">
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option1</RadioGroup.Label>
+                </RadioGroup.Item>
+                <RadioGroup.Item value="option2">
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option2</RadioGroup.Label>
+                </RadioGroup.Item>
+                <RadioGroup.Item value="option3">
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option3</RadioGroup.Label>
+                </RadioGroup.Item>
+            </RadioGroup.Root>,
+        );
+        const [option1, option2, option3] = rendered.getAllByRole('radio');
+
+        option1.focus();
+        await userEvent.keyboard('[Space]');
+
+        expect(option1).toHaveFocus();
+        expect(option1).toBeChecked();
+
+        await userEvent.keyboard('[ArrowDown]');
+        await userEvent.keyboard('[Space]');
+
+        expect(option2).toHaveFocus();
+        expect(option2).toBeChecked();
+
+        await userEvent.keyboard('[ArrowDown]');
+        await userEvent.keyboard('[Space]');
+
+        expect(option3).toHaveFocus();
+        expect(option3).toBeChecked();
+
+        await userEvent.keyboard('[ArrowUp]');
+        await userEvent.keyboard('[Space]');
+    });
+
+    it('should not include disabled items during keyboard navigation', async () => {
+        const rendered = render(
+            <RadioGroup.Root>
+                <RadioGroup.Item value="option1">
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option1</RadioGroup.Label>
+                </RadioGroup.Item>
+                <RadioGroup.Item value="option2" disabled>
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option2</RadioGroup.Label>
+                </RadioGroup.Item>
+                <RadioGroup.Item value="option3">
+                    <RadioGroup.Control />
+                    <RadioGroup.Label>option3</RadioGroup.Label>
+                </RadioGroup.Item>
+            </RadioGroup.Root>,
+        );
+        const [option1, _option2, option3] = rendered.getAllByRole('radio');
+
+        option1.focus();
+        await userEvent.keyboard('[Space]');
+
+        expect(option1).toHaveFocus();
+        expect(option1).toBeChecked();
+
+        await userEvent.keyboard('[ArrowDown]');
+        await userEvent.keyboard('[Space]');
+
+        expect(option3).toHaveFocus();
+        expect(option3).toBeChecked();
+
+        await userEvent.keyboard('[ArrowUp]');
+        await userEvent.keyboard('[Space]');
+
+        expect(option1).toHaveFocus();
+        expect(option1).toBeChecked();
+    });
+
     it('should automatically select radio upon navigation', async () => {
         const rendered = render(<RadioGroupTest />);
         const [firstItem, secondItem] = rendered.getAllByRole('radio');

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -256,7 +256,7 @@ describe('RadioGroup', () => {
         expect(secondItem).toHaveFocus();
 
         /**
-         * Note:
+         * NOTE
          * - When userEvent.keyboard([ArrowDown]) is input in the test environment, the checked state does not automatically change.
          * - Therefore, userEvent.keyboard([Space]) has been temporarily added to manually toggle the state.
          *

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -17,14 +17,14 @@ import { createSplitProps } from '~/utils/create-split-props';
 import type { ControlVariants, LabelVariants, RootVariants } from './radio-group.css';
 import * as styles from './radio-group.css';
 
-type RadixRootProps = ComponentPropsWithoutRef<typeof RadixRoot>;
-type PrimitiveRootProps = Pick<
-    RadixRootProps,
+type RadioGroupRootPrimitiveProps = ComponentPropsWithoutRef<typeof RadixRoot>;
+type RadioGroupBaseProps = Pick<
+    RadioGroupRootPrimitiveProps,
     'name' | 'dir' | 'loop' | 'value' | 'onValueChange' | 'defaultValue' | 'required' | 'disabled'
 >;
 
 type RadioGroupVariants = RootVariants & ControlVariants & LabelVariants;
-type RadioGroupSharedProps = RadioGroupVariants & PrimitiveRootProps;
+type RadioGroupSharedProps = RadioGroupVariants & RadioGroupBaseProps;
 type RadioGroupContext = RadioGroupSharedProps;
 
 const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupContext>({
@@ -37,33 +37,39 @@ const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupConte
  * RadioGroup.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type RadioGroupRootPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
 interface RadioGroupRootProps
-    extends Omit<RadioGroupRootPrimitiveProps, keyof PrimitiveRootProps>,
-        PrimitiveRootProps {}
+    extends Omit<RadioGroupRootPrimitiveProps, keyof RadioGroupBaseProps>,
+        RadioGroupSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, RadioGroupRootProps>(({ className, ...props }, ref) => {
-    const [sharedProps, otherProps] = createSplitProps<RadioGroupSharedProps>()(props, [
+    const [sharedProps, _otherProps] = createSplitProps<RadioGroupBaseProps>()(props, [
         'name',
-        'required',
-        'disabled',
         'value',
         'onValueChange',
         'defaultValue',
+        'disabled',
+        'required',
         'dir',
         'loop',
-        'orientation',
-        'invalid',
-        'size',
-        'visuallyHidden',
     ]);
 
-    const { size, orientation } = sharedProps;
+    const [variantProps, otherProps] = createSplitProps<RadioGroupVariants>()(_otherProps, [
+        'size',
+        'visuallyHidden',
+        'orientation',
+        'invalid',
+    ]);
+
+    const { disabled } = sharedProps;
+    const { size, orientation, invalid } = variantProps;
 
     return (
-        <RadioGroupProvider value={sharedProps}>
+        <RadioGroupProvider value={{ ...sharedProps, ...variantProps }}>
             <RadixRoot
                 ref={ref}
+                aria-invalid={invalid}
+                aria-disabled={disabled}
+                orientation={orientation}
                 className={clsx(styles.root({ size, orientation }), className)}
                 {...sharedProps}
                 {...otherProps}
@@ -78,10 +84,10 @@ Root.displayName = 'RadioGroup.Root';
  * -----------------------------------------------------------------------------------------------*/
 
 type RadioGroupItemPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+type RadioGroupItemBaseProps = Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
 
 type RadioGroupItemVariants = ControlVariants & LabelVariants;
-type RadioGroupItemSharedProps = RadioGroupItemVariants &
-    Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
+type RadioGroupItemSharedProps = RadioGroupItemVariants & RadioGroupItemBaseProps;
 
 type RadioGroupItemContext = RadioGroupItemSharedProps & {
     radioGroupItemId?: string;


### PR DESCRIPTION
- Wrote Unit tests for the RadioGroup component.
- Test is currently failing.
- This issue requires a modification to the component's implementation, which has been addressed in a separate pull request. ([here](https://github.com/goorm-dev/vapor-ui/pull/126))