### PR TITLE
fix(radio-group): remove incorrectly injected props

### DIFF
--- a/.changeset/brown-hats-shave.md
+++ b/.changeset/brown-hats-shave.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+fix: remove incorrectly injected props

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -67,10 +67,10 @@ const Root = forwardRef<HTMLDivElement, RadioGroupRootProps>(({ className, ...pr
         <RadioGroupProvider value={{ ...sharedProps, ...variantProps }}>
             <RadixRoot
                 ref={ref}
-                className={clsx(styles.root({ size, orientation }), className)}
                 aria-invalid={invalid}
                 aria-disabled={disabled}
                 orientation={orientation}
+                className={clsx(styles.root({ size, orientation }), className)}
                 {...sharedProps}
                 {...otherProps}
             />
@@ -84,10 +84,10 @@ Root.displayName = 'RadioGroup.Root';
  * -----------------------------------------------------------------------------------------------*/
 
 type RadioGroupItemPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+type RadioGroupItemBaseProps = Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
 
 type RadioGroupItemVariants = ControlVariants & LabelVariants;
-type RadioGroupItemSharedProps = RadioGroupItemVariants &
-    Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
+type RadioGroupItemSharedProps = RadioGroupItemVariants & RadioGroupItemBaseProps;
 
 type RadioGroupItemContext = RadioGroupItemSharedProps & {
     radioGroupItemId?: string;

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -17,14 +17,14 @@ import { createSplitProps } from '~/utils/create-split-props';
 import type { ControlVariants, LabelVariants, RootVariants } from './radio-group.css';
 import * as styles from './radio-group.css';
 
-type RadixRootProps = ComponentPropsWithoutRef<typeof RadixRoot>;
-type PrimitiveRootProps = Pick<
-    RadixRootProps,
+type RadioGroupRootPrimitiveProps = ComponentPropsWithoutRef<typeof RadixRoot>;
+type RadioGroupBaseProps = Pick<
+    RadioGroupRootPrimitiveProps,
     'name' | 'dir' | 'loop' | 'value' | 'onValueChange' | 'defaultValue' | 'required' | 'disabled'
 >;
 
 type RadioGroupVariants = RootVariants & ControlVariants & LabelVariants;
-type RadioGroupSharedProps = RadioGroupVariants & PrimitiveRootProps;
+type RadioGroupSharedProps = RadioGroupVariants & RadioGroupBaseProps;
 type RadioGroupContext = RadioGroupSharedProps;
 
 const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupContext>({
@@ -37,34 +37,40 @@ const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupConte
  * RadioGroup.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type RadioGroupRootPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
 interface RadioGroupRootProps
-    extends Omit<RadioGroupRootPrimitiveProps, keyof PrimitiveRootProps>,
-        PrimitiveRootProps {}
+    extends Omit<RadioGroupRootPrimitiveProps, keyof RadioGroupBaseProps>,
+        RadioGroupSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, RadioGroupRootProps>(({ className, ...props }, ref) => {
-    const [sharedProps, otherProps] = createSplitProps<RadioGroupSharedProps>()(props, [
+    const [sharedProps, _otherProps] = createSplitProps<RadioGroupBaseProps>()(props, [
         'name',
-        'required',
-        'disabled',
         'value',
         'onValueChange',
         'defaultValue',
+        'disabled',
+        'required',
         'dir',
         'loop',
-        'orientation',
-        'invalid',
-        'size',
-        'visuallyHidden',
     ]);
 
-    const { size, orientation } = sharedProps;
+    const [variantProps, otherProps] = createSplitProps<RadioGroupVariants>()(_otherProps, [
+        'size',
+        'visuallyHidden',
+        'orientation',
+        'invalid',
+    ]);
+
+    const { disabled } = sharedProps;
+    const { size, orientation, invalid } = variantProps;
 
     return (
-        <RadioGroupProvider value={sharedProps}>
+        <RadioGroupProvider value={{ ...sharedProps, ...variantProps }}>
             <RadixRoot
                 ref={ref}
                 className={clsx(styles.root({ size, orientation }), className)}
+                aria-invalid={invalid}
+                aria-disabled={disabled}
+                orientation={orientation}
                 {...sharedProps}
                 {...otherProps}
             />


### PR DESCRIPTION
- During this [PR](https://github.com/goorm-dev/vapor-ui/pull/125), a functional bug was discovered and fixed:
- variant props (e.g., visuallyHidden) were being incorrectly injected as HTML tag attributes, leading to error logs in the browser console.
- This was resolved by separating variantProps and sharedProps