### PR TITLE
fix: Add z-index values in dialog and add sync with overflow.

### DIFF
--- a/packages/core/src/components/dialog/dialog.css.ts
+++ b/packages/core/src/components/dialog/dialog.css.ts
@@ -20,6 +20,7 @@ export const overlay = layerStyle('vapor-component', {
     inset: 0,
     transition: 'opacity 0.2s cubic-bezier(0.175,0.885,0.32,1.1)',
     backgroundColor: vars.color['black'],
+    zIndex: 50, // TODO: Use constant z-index value
 
     selectors: {
         "&[data-state='open']": { animation: `${fadeIn} 0.2s ease-out forwards` },
@@ -51,6 +52,7 @@ export const content = recipe({
 
         boxShadow: '0 1rem 2rem 0 rgba(0, 0, 0, 0.2)',
         backgroundColor: vars.color.background['normal-lighter'],
+        zIndex: 50, // TODO: Use constant z-index value
 
         selectors: {
             "&[data-state='open']": {


### PR DESCRIPTION
## 📝 Description of Changes

- Add default z-index in dialog and TODO comment for any other zIndex things.
- Add maxHeight for Scroll type in Design system.

## 📸 Screenshots

<img width="4608" height="1696" alt="Screenshot 2025-07-30 at 17-51-57 Dialog - Vapor UI" src="https://github.com/user-attachments/assets/215239b4-c997-4e73-853e-9e2009df1b67" />

## ✅ Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [x] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
