### PR TITLE
fix(style): Add foreground mixin to style entry point

### DIFF
--- a/.changeset/fine-buttons-pull.md
+++ b/.changeset/fine-buttons-pull.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+fix(Text): Add foreground mixin to style entry point

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -2,16 +2,20 @@
 // ⚠️ IMPORTANT: The import order is crucial to avoid circular dependencies.
 // 1. Define CSS layers (must be first)
 import './global-var.css';
+
 // 2. Global reset styles
 import './global.css';
 import './layers.css';
-import './mixins/foreground.css';
-// 5. Utility styles
-import './sprinkles.css';
-// 4. Assign theme values (after the contract is created)
-import './theme.css';
+
 // 3. Create CSS variable contract
 import './vars.css';
+
+// 4. Assign theme values (after the contract is created)
+import './theme.css';
+
+// 5. Utility styles
+import './sprinkles.css';
+import './mixins/foreground.css';
 
 
 import '../components/avatar/avatar.css';

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -5,6 +5,7 @@ import './global-var.css';
 // 2. Global reset styles
 import './global.css';
 import './layers.css';
+import './mixins/foreground.css';
 // 5. Utility styles
 import './sprinkles.css';
 // 4. Assign theme values (after the contract is created)


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## 🔗Related Issues

#141 

## 📝 Description of Changes

This PR fixes a bug where the `foreground` utility was not being applied because its mixin was missing from the main style entry point.

- **Problem:** The CSS for the `foreground` utility was not included in the final stylesheet build.
- **Solution:** Added the `foreground` mixin to the style entry point, ensuring it is correctly compiled and bundled.

**Out of Scope:**
This change is a hotfix focused solely on resolving the `foreground` issue. It does not include a broader refactoring of the style import structure.
## 📸 Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

<img width="712" height="694" alt="스크린샷 2025-07-31 13 27 06" src="https://github.com/user-attachments/assets/3a8202a0-6e78-474c-9018-a5ec1a11b170" />


## ✅ Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [x] I have added tests for my changes.
- [x] I have updated the Storybook or relevant documentation.
- [x] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
