### PR TITLE
fix: resolve errors about unit test

### DIFF
--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -1,4 +1,6 @@
-import { render, waitFor } from '@testing-library/react';
+import { act } from 'react';
+
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'vitest-axe';
 
@@ -181,7 +183,7 @@ describe('RadioGroup', () => {
         );
         const [option1, option2, option3] = rendered.getAllByRole('radio');
 
-        waitFor(() => option1.focus());
+        act(() => option1.focus());
         await userEvent.keyboard('[Space]');
 
         expect(option1).toHaveFocus();
@@ -222,7 +224,7 @@ describe('RadioGroup', () => {
         );
         const [option1, _option2, option3] = rendered.getAllByRole('radio');
 
-        option1.focus();
+        act(() => option1.focus());
         await userEvent.keyboard('[Space]');
 
         expect(option1).toHaveFocus();
@@ -245,7 +247,7 @@ describe('RadioGroup', () => {
         const rendered = render(<RadioGroupTest />);
         const [firstItem, secondItem] = rendered.getAllByRole('radio');
 
-        firstItem.focus();
+        act(() => firstItem.focus());
 
         expect(firstItem).toHaveFocus();
         expect(firstItem).not.toBeChecked();

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'vitest-axe';
 
@@ -181,7 +181,7 @@ describe('RadioGroup', () => {
         );
         const [option1, option2, option3] = rendered.getAllByRole('radio');
 
-        option1.focus();
+        waitFor(() => option1.focus());
         await userEvent.keyboard('[Space]');
 
         expect(option1).toHaveFocus();

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
             '~': path.resolve(__dirname, 'src'),
         },
     },
+    ssr: {
+        noExternal: ['@vapor-ui/icons'],
+    },
     test: {
         setupFiles: ['./__tests__/setup-tests.ts'],
         environment: 'happy-dom',


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## 🔗 Related Issues

<!-- Please add any related issue numbers or links. -->
<!-- e.g., Fixes #123 -->
<!-- e.g., Notion: Design System Meeting Notes -->

- X

## 📝 Description of Changes

<!-- Please provide a brief summary of the changes in this PR. -->
<!-- e.g., Added new Avatar component -->
<!-- e.g., Updated Color tokens to support dark mode -->
<!-- e.g., Fixed styles for the disabled state in the Input component -->

1. When the `focus()` method is called, it internally updates React's state. React Testing Library (RTL) requires that any action causing a state update must be wrapped in the act() function. This was not being done, which was causing a warning message.


2. Added @vapor-ui/icons to the ssr.noExternal field.
    - Packages provided to ssr.noExternal are included in the bundle at build time.
    - Previously, @vapor-ui/icons was not included in the build bundle, resulting in an error.
    - Therefore, the configuration has been updated to include @vapor-ui/icons in the test environment.

## 📸 Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## ✅ Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [x] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
