### PR TITLE
feat: add VComponentProps

### DIFF
--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import {
@@ -14,6 +13,7 @@ import clsx from 'clsx';
 import { createContext } from '~/libs/create-context';
 import { vars } from '~/styles/vars.css';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { FallbackVariants, RootVariants } from './avatar.css';
 import * as styles from './avatar.css';
@@ -29,7 +29,7 @@ const [AvatarProvider, useAvatarContext] = createContext<AvatarSharedProps>({
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type AvatarRootPrimitiveProps = ComponentPropsWithoutRef<typeof RadixAvatar>;
+type AvatarRootPrimitiveProps = VComponentProps<typeof RadixAvatar>;
 interface AvatarRootProps extends AvatarRootPrimitiveProps, AvatarSharedProps {}
 
 const Root = forwardRef<HTMLSpanElement, AvatarRootProps>(({ className, ...props }, ref) => {
@@ -59,7 +59,7 @@ Root.displayName = 'Avatar.Root';
  * Avatar.Image
  * -----------------------------------------------------------------------------------------------*/
 
-type AvatarImagePrimitiveProps = ComponentPropsWithoutRef<typeof RadixImage>;
+type AvatarImagePrimitiveProps = VComponentProps<typeof RadixImage>;
 interface AvatarImageProps extends Omit<AvatarImagePrimitiveProps, keyof AvatarSharedProps> {}
 
 const Image = forwardRef<HTMLImageElement, AvatarImageProps>(({ className, ...props }, ref) => {
@@ -81,7 +81,7 @@ Image.displayName = 'Avatar.Image';
  * Avatar.Fallback
  * -----------------------------------------------------------------------------------------------*/
 
-type AvatarFallbackPrimitiveProps = ComponentPropsWithoutRef<typeof RadixFallback>;
+type AvatarFallbackPrimitiveProps = VComponentProps<typeof RadixFallback>;
 interface AvatarFallbackProps extends Omit<AvatarFallbackPrimitiveProps, keyof AvatarSharedProps> {}
 
 const Fallback = forwardRef<HTMLSpanElement, AvatarFallbackProps>(

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { BadgeVariants } from './badge.css';
 import * as styles from './badge.css';
 
-type BadgePrimitiveProps = Omit<ComponentPropsWithoutRef<typeof Primitive.span>, 'color'>;
+type BadgePrimitiveProps = Omit<VComponentProps<typeof Primitive.span>, 'color'>;
 interface BadgeProps extends BadgePrimitiveProps, BadgeVariants {}
 
 const Badge = forwardRef<HTMLSpanElement, BadgeProps>(({ className, children, ...props }, ref) => {

--- a/packages/core/src/components/box/box.tsx
+++ b/packages/core/src/components/box/box.tsx
@@ -10,18 +10,24 @@ import type { VComponentProps } from '~/utils/types';
 
 interface BoxProps extends VComponentProps<typeof Primitive.div>, Sprinkles {}
 
-const Box = forwardRef<HTMLDivElement, BoxProps>(({ className, style, ...props }, ref) => {
-    const { className: layoutClassName, style: layoutStyle, otherProps } = sprinkles(props);
+const Box = forwardRef<HTMLDivElement, BoxProps>(
+    ({ foregroundColor: color, className, style, ...props }, ref) => {
+        const {
+            className: layoutClassName,
+            style: layoutStyle,
+            otherProps,
+        } = sprinkles({ color, ...props });
 
-    return (
-        <Primitive.div
-            ref={ref}
-            className={clsx(layoutClassName, className)}
-            style={{ ...layoutStyle, ...style }}
-            {...otherProps}
-        />
-    );
-});
+        return (
+            <Primitive.div
+                ref={ref}
+                className={clsx(layoutClassName, className)}
+                style={{ ...layoutStyle, ...style }}
+                {...otherProps}
+            />
+        );
+    },
+);
 Box.displayName = 'Box';
 
 export { Box };

--- a/packages/core/src/components/box/box.tsx
+++ b/packages/core/src/components/box/box.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
 import { type Sprinkles, sprinkles } from '~/styles/sprinkles.css';
+import type { VComponentProps } from '~/utils/types';
 
-interface BoxProps extends ComponentPropsWithoutRef<typeof Primitive.div>, Sprinkles {}
+interface BoxProps extends VComponentProps<typeof Primitive.div>, Sprinkles {}
 
 const Box = forwardRef<HTMLDivElement, BoxProps>(({ className, style, ...props }, ref) => {
     const { className: layoutClassName, style: layoutStyle, otherProps } = sprinkles(props);

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { ButtonVariants } from './button.css';
 import * as styles from './button.css';
 
-type ButtonPrimitiveProps = Omit<ComponentPropsWithoutRef<typeof Primitive.button>, 'color'>;
+type ButtonPrimitiveProps = VComponentProps<typeof Primitive.button>;
 interface ButtonProps extends ButtonPrimitiveProps, ButtonVariants {}
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { CalloutVariants } from './callout.css';
 import * as styles from './callout.css';
@@ -15,8 +15,8 @@ import * as styles from './callout.css';
  * Callout
  * -----------------------------------------------------------------------------------------------*/
 
-type CalloutPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
-interface CalloutProps extends Omit<CalloutPrimitiveProps, 'color'>, CalloutVariants {}
+type CalloutPrimitiveProps = VComponentProps<typeof Primitive.div>;
+interface CalloutProps extends CalloutPrimitiveProps, CalloutVariants {}
 
 const Callout = forwardRef<HTMLDivElement, CalloutProps>(
     ({ className, children, ...props }, ref) => {

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
+
+import type { VComponentProps } from '~/utils/types';
 
 import * as styles from './card.css';
 
@@ -12,7 +13,7 @@ import * as styles from './card.css';
  * Card.Root
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardRootProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface CardRootProps extends VComponentProps<typeof Primitive.div> {}
 
 const Root = forwardRef<HTMLDivElement, CardRootProps>(({ className, children, ...props }, ref) => {
     return (
@@ -27,7 +28,7 @@ Root.displayName = 'Card';
  * Card.Header
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardHeaderProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface CardHeaderProps extends VComponentProps<typeof Primitive.div> {}
 
 const Header = forwardRef<HTMLDivElement, CardHeaderProps>(
     ({ className, children, ...props }, ref) => {
@@ -44,7 +45,7 @@ Header.displayName = 'Card.Header';
  * Card.Body
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardBodyProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface CardBodyProps extends VComponentProps<typeof Primitive.div> {}
 
 const Body = forwardRef<HTMLDivElement, CardBodyProps>(({ className, children, ...props }, ref) => {
     return (
@@ -59,7 +60,7 @@ Body.displayName = 'Card.Body';
  * Card.Footer
  * -----------------------------------------------------------------------------------------------*/
 
-interface CardFooterProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface CardFooterProps extends VComponentProps<typeof Primitive.div> {}
 
 const Footer = forwardRef<HTMLDivElement, CardFooterProps>(
     ({ className, children, ...props }, ref) => {

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef, useId } from 'react';
 
 import type { CheckedState } from '@radix-ui/react-checkbox';
@@ -11,6 +10,7 @@ import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { ControlVariants, LabelVariants, RootVariants } from './checkbox.css';
 import * as styles from './checkbox.css';
@@ -37,10 +37,8 @@ const [CheckboxProvider, useCheckboxContext] = createContext<CheckboxContext>({
  * Checkbox.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveRootProps = ComponentPropsWithoutRef<typeof Primitive.div>;
-interface CheckboxRootProps
-    extends Omit<PrimitiveRootProps, keyof CheckboxSharedProps>,
-        CheckboxSharedProps {}
+type PrimitiveRootProps = VComponentProps<typeof Primitive.div>;
+interface CheckboxRootProps extends PrimitiveRootProps, CheckboxSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, CheckboxRootProps>(({ className, ...props }, ref) => {
     const checkboxId = useId();
@@ -73,7 +71,7 @@ Root.displayName = 'Checkbox.Root';
  * Checkbox.Label
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveLabelProps = ComponentPropsWithoutRef<typeof Primitive.label>;
+type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
 interface CheckboxLabelProps extends PrimitiveLabelProps {}
 
 const Label = forwardRef<HTMLLabelElement, CheckboxLabelProps>(
@@ -95,7 +93,7 @@ const Label = forwardRef<HTMLLabelElement, CheckboxLabelProps>(
  * Checkbox.Control
  * -----------------------------------------------------------------------------------------------*/
 
-type ControlPrimitiveProps = ComponentPropsWithoutRef<typeof RadixRoot>;
+type ControlPrimitiveProps = VComponentProps<typeof RadixRoot>;
 interface CheckboxControlProps extends Omit<ControlPrimitiveProps, keyof CheckboxSharedProps> {}
 
 const Control = forwardRef<HTMLButtonElement, CheckboxControlProps>(
@@ -146,7 +144,7 @@ Control.displayName = 'Checkbox.Control';
  * Icons
  * -----------------------------------------------------------------------------------------------*/
 
-interface IconProps extends ComponentPropsWithoutRef<'svg'> {}
+interface IconProps extends VComponentProps<'svg'> {}
 
 const CheckIcon = (props: IconProps) => {
     return (

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import {
@@ -17,6 +16,7 @@ import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
+import type { VComponentProps } from '~/utils/types';
 
 import * as styles from './dialog.css';
 import type { DialogContentVariants } from './dialog.css';
@@ -37,7 +37,7 @@ const [DialogRoot, useDialogContext] = createContext<DialogContext>({
  * Dialog
  * -----------------------------------------------------------------------------------------------*/
 
-type DialogPrimitiveProps = ComponentPropsWithoutRef<typeof RadixDialog>;
+type DialogPrimitiveProps = VComponentProps<typeof RadixDialog>;
 interface DialogRootProps extends DialogPrimitiveProps, DialogSharedProps {}
 
 const Root = ({
@@ -58,7 +58,7 @@ const Root = ({
  * Dialog.Portal
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogPortalProps extends ComponentPropsWithoutRef<typeof RadixPortal> {}
+interface DialogPortalProps extends VComponentProps<typeof RadixPortal> {}
 
 const Portal = RadixPortal;
 Portal.displayName = 'Dialog.Portal';
@@ -67,7 +67,7 @@ Portal.displayName = 'Dialog.Portal';
  * Dialog.Overlay
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogOverlayProps extends ComponentPropsWithoutRef<typeof RadixOverlay> {}
+interface DialogOverlayProps extends VComponentProps<typeof RadixOverlay> {}
 
 const Overlay = forwardRef<HTMLDivElement, DialogOverlayProps>(({ className, ...props }, ref) => {
     return <RadixOverlay ref={ref} className={clsx(styles.overlay, className)} {...props} />;
@@ -79,7 +79,7 @@ Overlay.displayName = 'Dialog.Overlay';
  * -----------------------------------------------------------------------------------------------*/
 
 type PointerDownOutsideEvent = CustomEvent<{ originalEvent: PointerEvent }>;
-interface DialogContentProps extends ComponentPropsWithoutRef<typeof RadixContent> {}
+interface DialogContentProps extends VComponentProps<typeof RadixContent> {}
 
 const Content = forwardRef<HTMLDivElement, DialogContentProps>(
     ({ onPointerDownOutside, onEscapeKeyDown, className, ...props }, ref) => {
@@ -130,7 +130,7 @@ CombinedContent.displayName = 'Dialog.CombinedContent';
  * Dialog.Trigger
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogTriggerProps extends ComponentPropsWithoutRef<typeof RadixTrigger> {}
+interface DialogTriggerProps extends VComponentProps<typeof RadixTrigger> {}
 
 const Trigger = forwardRef<HTMLButtonElement, DialogTriggerProps>((props, ref) => {
     return <RadixTrigger ref={ref} aria-controls={undefined} {...props} />;
@@ -141,7 +141,7 @@ Trigger.displayName = 'Dialog.Trigger';
  * Dialog.Close
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogCloseProps extends ComponentPropsWithoutRef<typeof RadixClose> {}
+interface DialogCloseProps extends VComponentProps<typeof RadixClose> {}
 
 const Close = forwardRef<HTMLButtonElement, DialogCloseProps>((props, ref) => {
     return <RadixClose ref={ref} {...props} />;
@@ -152,7 +152,7 @@ Close.displayName = 'Dialog.Close';
  * Dialog.Title
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogTitleProps extends ComponentPropsWithoutRef<typeof RadixTitle> {}
+interface DialogTitleProps extends VComponentProps<typeof RadixTitle> {}
 
 const Title = forwardRef<HTMLHeadingElement, DialogTitleProps>(({ className, ...props }, ref) => {
     return <RadixTitle ref={ref} className={clsx(styles.title, className)} {...props} />;
@@ -163,7 +163,7 @@ Title.displayName = 'Dialog.Title';
  * Dialog.Description
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogDescriptionProps extends ComponentPropsWithoutRef<typeof RadixDescription> {}
+interface DialogDescriptionProps extends VComponentProps<typeof RadixDescription> {}
 
 const Description = forwardRef<HTMLParagraphElement, DialogDescriptionProps>(
     ({ className, ...props }, ref) => {
@@ -182,7 +182,7 @@ Description.displayName = 'Dialog.Description';
  * Dialog.Header
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogHeaderProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface DialogHeaderProps extends VComponentProps<typeof Primitive.div> {}
 
 const Header = forwardRef<HTMLDivElement, DialogHeaderProps>(({ className, ...props }, ref) => {
     return <Primitive.div ref={ref} className={clsx(styles.header, className)} {...props} />;
@@ -193,7 +193,7 @@ Header.displayName = 'Dialog.Header';
  * Dialog.Body
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogBodyProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface DialogBodyProps extends VComponentProps<typeof Primitive.div> {}
 
 const Body = forwardRef<HTMLDivElement, DialogBodyProps>(({ className, ...props }, ref) => {
     return <Primitive.div ref={ref} className={clsx(styles.body, className)} {...props} />;
@@ -204,7 +204,7 @@ Body.displayName = 'Dialog.Body';
  * Dialog.Footer
  * -----------------------------------------------------------------------------------------------*/
 
-interface DialogFooterProps extends ComponentPropsWithoutRef<typeof Primitive.div> {}
+interface DialogFooterProps extends VComponentProps<typeof Primitive.div> {}
 
 const Footer = forwardRef<HTMLDivElement, DialogFooterProps>(({ className, ...props }, ref) => {
     return <Primitive.div ref={ref} className={clsx(styles.footer, className)} {...props} />;

--- a/packages/core/src/components/flex/flex.tsx
+++ b/packages/core/src/components/flex/flex.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import { Box } from '../box';
 
 type FlexVariants = { inline?: boolean };
-type FlexPrimitiveProps = ComponentPropsWithoutRef<typeof Box>;
+type FlexPrimitiveProps = VComponentProps<typeof Box>;
 
 interface FlexProps extends FlexPrimitiveProps, FlexVariants {}
 

--- a/packages/core/src/components/grid/grid.tsx
+++ b/packages/core/src/components/grid/grid.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import type { CSSProperties, ComponentPropsWithoutRef } from 'react';
+import type { CSSProperties } from 'react';
 import { forwardRef } from 'react';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import { Box } from '../box';
 import type { RootVariants } from './grid.css';
@@ -16,7 +17,7 @@ import * as styles from './grid.css';
  * Grid
  * -----------------------------------------------------------------------------------------------*/
 
-type GridPrimitiveProps = ComponentPropsWithoutRef<typeof Box>;
+type GridPrimitiveProps = VComponentProps<typeof Box>;
 type GridVariants = RootVariants & {
     inline?: boolean;
     templateRows?: string;
@@ -61,7 +62,7 @@ Root.displayName = 'Grid';
  * Grid.Item
  * -----------------------------------------------------------------------------------------------*/
 
-type GridItemPrimitiveProps = ComponentPropsWithoutRef<typeof Box>;
+type GridItemPrimitiveProps = VComponentProps<typeof Box>;
 type GridItemVariants = { rowSpan?: string; colSpan?: string };
 
 interface GridItemProps extends GridItemPrimitiveProps, GridItemVariants {}

--- a/packages/core/src/components/h-stack/h-stack.stories.tsx
+++ b/packages/core/src/components/h-stack/h-stack.stories.tsx
@@ -61,7 +61,7 @@ const CustomBox = ({ size = 50, ...props }: ComponentProps<typeof Box> & { size?
             border="1px solid white"
             textAlign="center"
             alignContent="center"
-            color="white"
+            foregroundColor="$contrast"
             {...props}
         />
     );

--- a/packages/core/src/components/h-stack/h-stack.tsx
+++ b/packages/core/src/components/h-stack/h-stack.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import { Flex } from '../flex';
 
 type HStackVariants = { reverse?: boolean };
-type HStackPrimitiveProps = ComponentPropsWithoutRef<typeof Flex>;
+type HStackPrimitiveProps = VComponentProps<typeof Flex>;
 
 interface HStackProps extends HStackPrimitiveProps, HStackVariants {}
 

--- a/packages/core/src/components/icon-button/icon-button.tsx
+++ b/packages/core/src/components/icon-button/icon-button.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import clsx from 'clsx';
 
 import { createSlot } from '~/libs/create-slot';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import { Button } from '../button';
 import type { IconButtonVariants } from './icon-button.css';
 import * as styles from './icon-button.css';
 
-type IconButtonPrimitiveProps = Omit<ComponentPropsWithoutRef<typeof Button>, 'stretch'>;
+type IconButtonPrimitiveProps = Omit<VComponentProps<typeof Button>, 'stretch'>;
 interface IconButtonProps extends IconButtonVariants, IconButtonPrimitiveProps {
     'aria-label': string;
 }

--- a/packages/core/src/components/nav/nav.tsx
+++ b/packages/core/src/components/nav/nav.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import {
@@ -13,6 +12,7 @@ import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { ItemVariants, LinkVariants, ListVariants } from './nav.css';
 import * as styles from './nav.css';
@@ -29,7 +29,7 @@ const [NavProvider, useNavContext] = createContext<NavContextType>({
  * -----------------------------------------------------------------------------------------------*/
 
 type NavVariants = ListVariants & ItemVariants & LinkVariants;
-type NavPrimitiveProps = ComponentPropsWithoutRef<typeof RadixRoot>;
+type NavPrimitiveProps = VComponentProps<typeof RadixRoot>;
 
 interface NavRootProps extends NavPrimitiveProps, NavVariants {
     'aria-label': string;
@@ -64,7 +64,7 @@ Root.displayName = 'Nav.Root';
  * Nav.List
  * -----------------------------------------------------------------------------------------------*/
 
-type ListPrimitiveProps = ComponentPropsWithoutRef<typeof RadixList>;
+type ListPrimitiveProps = VComponentProps<typeof RadixList>;
 interface NavMenuList extends ListPrimitiveProps {}
 
 const List = forwardRef<HTMLUListElement, NavMenuList>(({ className, ...props }, ref) => {
@@ -84,7 +84,7 @@ List.displayName = 'Nav.List';
  * Nav.Item
  * -----------------------------------------------------------------------------------------------*/
 
-type ItemPrimitiveProps = ComponentPropsWithoutRef<typeof RadixItem>;
+type ItemPrimitiveProps = VComponentProps<typeof RadixItem>;
 interface NavItemProps extends ItemPrimitiveProps {}
 
 const Item = forwardRef<HTMLLIElement, NavItemProps>(({ className, ...props }, ref) => {
@@ -98,7 +98,7 @@ Item.displayName = 'Nav.Item';
  * Nav.Link
  * -----------------------------------------------------------------------------------------------*/
 
-type LinkPrimitiveProps = Omit<ComponentPropsWithoutRef<typeof RadixLink>, 'active'>;
+type LinkPrimitiveProps = Omit<VComponentProps<typeof RadixLink>, 'active'>;
 interface NavLinkProps extends LinkPrimitiveProps {
     selected?: boolean;
     disabled?: boolean;
@@ -128,7 +128,7 @@ Link.displayName = 'Nav.Link';
  * Nav.LinkItem
  * -----------------------------------------------------------------------------------------------*/
 
-interface NavLinkItemProps extends ComponentPropsWithoutRef<typeof Link> {}
+interface NavLinkItemProps extends VComponentProps<typeof Link> {}
 
 const LinkItem = forwardRef<HTMLAnchorElement, NavLinkItemProps>((props, ref) => {
     return (

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -13,13 +13,13 @@ import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { ControlVariants, LabelVariants, RootVariants } from './radio-group.css';
 import * as styles from './radio-group.css';
 
-type RadioGroupRootPrimitiveProps = ComponentPropsWithoutRef<typeof RadixRoot>;
 type RadioGroupBaseProps = Pick<
-    RadioGroupRootPrimitiveProps,
+    ComponentPropsWithoutRef<typeof RadixRoot>,
     'name' | 'dir' | 'loop' | 'value' | 'onValueChange' | 'defaultValue' | 'required' | 'disabled'
 >;
 
@@ -37,9 +37,8 @@ const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupConte
  * RadioGroup.Root
  * -----------------------------------------------------------------------------------------------*/
 
-interface RadioGroupRootProps
-    extends Omit<RadioGroupRootPrimitiveProps, keyof RadioGroupBaseProps>,
-        RadioGroupSharedProps {}
+type RadioGroupRootPrimitiveProps = VComponentProps<typeof Primitive.div>;
+interface RadioGroupRootProps extends RadioGroupRootPrimitiveProps, RadioGroupSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, RadioGroupRootProps>(({ className, ...props }, ref) => {
     const [sharedProps, _otherProps] = createSplitProps<RadioGroupBaseProps>()(props, [
@@ -83,7 +82,7 @@ Root.displayName = 'RadioGroup.Root';
  * RadioGroup.Item
  * -----------------------------------------------------------------------------------------------*/
 
-type RadioGroupItemPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+type RadioGroupItemPrimitiveProps = VComponentProps<typeof Primitive.div>;
 type RadioGroupItemBaseProps = Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
 
 type RadioGroupItemVariants = ControlVariants & LabelVariants;
@@ -137,8 +136,7 @@ Item.displayName = 'RadioGroup.Item';
  * RadioGroup.Control
  * -----------------------------------------------------------------------------------------------*/
 
-type RadioGroupControlPrimitiveProps = ComponentPropsWithoutRef<typeof RadixItem>;
-
+type RadioGroupControlPrimitiveProps = VComponentProps<typeof RadixItem>;
 interface RadioGroupControlProps
     extends Omit<RadioGroupControlPrimitiveProps, keyof RadioGroupItemSharedProps> {}
 
@@ -168,7 +166,7 @@ Control.displayName = 'RadioGroup.Control';
  * RadioGroup.Label
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveLabelProps = ComponentPropsWithoutRef<typeof Primitive.label>;
+type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
 interface RadioGroupLabelProps extends Omit<PrimitiveLabelProps, keyof RadioGroupItemSharedProps> {}
 
 const Label = forwardRef<HTMLLabelElement, RadioGroupLabelProps>(

--- a/packages/core/src/components/switch/switch.tsx
+++ b/packages/core/src/components/switch/switch.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef, useId } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
@@ -9,6 +8,7 @@ import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { ControlVariants, LabelVariants, RootVariants } from './switch.css';
 import * as styles from './switch.css';
@@ -35,10 +35,8 @@ const [SwitchProvider, useSwitchContext] = createContext<SwitchContext>({
  * Switch.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type SwitchRootPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
-interface SwitchRootProps
-    extends Omit<SwitchRootPrimitiveProps, keyof SwitchSharedProps>,
-        SwitchSharedProps {}
+type SwitchRootPrimitiveProps = VComponentProps<typeof Primitive.div>;
+interface SwitchRootProps extends SwitchRootPrimitiveProps, SwitchSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, SwitchRootProps>(({ className, ...props }, ref) => {
     const switchId = useId();
@@ -69,7 +67,7 @@ Root.displayName = 'Switch.Root';
  * Switch.Label
  * -----------------------------------------------------------------------------------------------*/
 
-type SwitchLabelPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.label>;
+type SwitchLabelPrimitiveProps = VComponentProps<typeof Primitive.label>;
 interface SwitchLabelProps extends SwitchLabelPrimitiveProps {}
 
 const Label = forwardRef<HTMLLabelElement, SwitchLabelProps>(
@@ -92,7 +90,7 @@ Label.displayName = 'Switch.Label';
  * Switch.Control
  * -----------------------------------------------------------------------------------------------*/
 
-type SwitchControlPrimitiveProps = ComponentPropsWithoutRef<typeof RadixSwitchRoot>;
+type SwitchControlPrimitiveProps = VComponentProps<typeof RadixSwitchRoot>;
 interface SwitchControlProps extends Omit<SwitchControlPrimitiveProps, keyof SwitchSharedProps> {}
 
 const Control = forwardRef<HTMLButtonElement, SwitchControlProps>(

--- a/packages/core/src/components/text-input/text-input.tsx
+++ b/packages/core/src/components/text-input/text-input.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef, useId } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
@@ -8,6 +7,7 @@ import clsx from 'clsx';
 
 import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import type { FieldVariants, LabelVariants, RootVariants } from './text-input.css';
 import * as styles from './text-input.css';
@@ -36,10 +36,8 @@ const [TextInputProvider, useTextInputContext] = createContext<TextInputContextT
  * TextInput
  * -----------------------------------------------------------------------------------------------*/
 
-type TextInputPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.div>;
-interface TextInputRootProps
-    extends Omit<TextInputPrimitiveProps, keyof TextInputSharedProps>,
-        TextInputSharedProps {}
+type TextInputPrimitiveProps = VComponentProps<typeof Primitive.div>;
+interface TextInputRootProps extends TextInputPrimitiveProps, TextInputSharedProps {}
 
 const Root = forwardRef<HTMLDivElement, TextInputRootProps>(
     ({ className, children, ...props }, ref) => {
@@ -78,7 +76,7 @@ Root.displayName = 'TextInput.Root';
  * TextInput.Label
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveLabelProps = ComponentPropsWithoutRef<typeof Primitive.label>;
+type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
 interface TextInputLabelProps extends PrimitiveLabelProps {}
 
 const Label = forwardRef<HTMLLabelElement, TextInputLabelProps>(
@@ -101,7 +99,7 @@ Label.displayName = 'TextInput.Label';
  * TextInput.Field
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveInputProps = ComponentPropsWithoutRef<typeof Primitive.input>;
+type PrimitiveInputProps = VComponentProps<typeof Primitive.input>;
 interface TextInputFieldProps extends Omit<PrimitiveInputProps, keyof TextInputSharedProps> {}
 
 const Field = forwardRef<HTMLInputElement, TextInputFieldProps>(

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
@@ -9,8 +8,9 @@ import clsx from 'clsx';
 import type { Foregrounds } from '~/styles/mixins/foreground.css';
 import { foregrounds } from '~/styles/mixins/foreground.css';
 import { type Typography, typography } from '~/styles/mixins/typography.css';
+import type { VComponentProps } from '~/utils/types';
 
-type TextPrimitiveProps = ComponentPropsWithoutRef<typeof Primitive.span>;
+type TextPrimitiveProps = VComponentProps<typeof Primitive.span>;
 interface TextProps extends TextPrimitiveProps {
     foreground?: Foregrounds['color'];
     typography?: Typography['style'];

--- a/packages/core/src/components/v-stack/v-stack.stories.tsx
+++ b/packages/core/src/components/v-stack/v-stack.stories.tsx
@@ -61,7 +61,7 @@ const CustomBox = ({ size = 50, ...props }: ComponentProps<typeof Box> & { size?
             border="1px solid white"
             textAlign="center"
             alignContent="center"
-            color="white"
+            foregroundColor="$accent"
             {...props}
         />
     );

--- a/packages/core/src/components/v-stack/v-stack.tsx
+++ b/packages/core/src/components/v-stack/v-stack.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef } from 'react';
 
 import { createSplitProps } from '~/utils/create-split-props';
+import type { VComponentProps } from '~/utils/types';
 
 import { Flex } from '../flex';
 
 type VStackVariants = { reverse?: boolean };
-type VStackPrimitiveProps = ComponentPropsWithoutRef<typeof Flex>;
+type VStackPrimitiveProps = VComponentProps<typeof Flex>;
 
 interface VStackProps extends VStackPrimitiveProps, VStackVariants {}
 

--- a/packages/core/src/styles/sprinkles.css.ts
+++ b/packages/core/src/styles/sprinkles.css.ts
@@ -245,5 +245,5 @@ const sprinkleProperties = defineProperties({
 
 export const sprinkles = createRainbowSprinkles(sprinkleProperties);
 export type Sprinkles = Omit<Parameters<typeof sprinkles>[0], 'color'> & {
-    foregroundColor?: `${keyof typeof foreground}`;
+    foregroundColor?: `$${keyof typeof foreground}`;
 };

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -1,0 +1,9 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+type ColorPropToOmit<ElementType extends React.ElementType> =
+    string extends ComponentPropsWithoutRef<ElementType>['color'] ? 'color' : never;
+
+export type VComponentProps<ElementType extends React.ElementType> = Omit<
+    ComponentPropsWithoutRef<ElementType>,
+    'defaultValue' | 'defaultChecked' | 'dir' | ColorPropToOmit<ElementType>
+>;


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## Related Issues

<!-- Please add any related issue numbers or links. -->
<!-- e.g., Fixes #123 -->
<!-- e.g., Notion: Design System Meeting Notes -->

## Description of Changes

- Previously, we sometimes had to manually Omit props like color or defaultValue due to conflicts with native HTML attributes.

```tsx
// ex
type ButtonVariants = {
    color?: 'primary' | 'secondary' | ...
}

interface ButtonProps extends ComponentProps<'button'>, ButtonVariants {}
              // ~~~~~~~~~~ This causes an error
```

- Although the color attribute still exists in HTML, it was an attribute for the <font /> tag, both of which are now deprecated. Therefore, it is no longer in use.
- In addition, attributes such as dir, defaultChecked, and defaultValue are either handled by headless librariesor are elements we add ourselves. To eliminate conflicts with the native element's attributes, we have Omitted them.

<!-- Please provide a brief summary of the changes in this PR. -->
<!-- e.g., Added new Avatar component -->
<!-- e.g., Updated Color tokens to support dark mode -->
<!-- e.g., Fixed styles for the disabled state in the Input component -->

## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [x] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
