### PR TITLE
chore: ignore formatting side-effect import

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,7 +6,8 @@ module.exports = {
     printWidth: 100,
 
     plugins: ['@trivago/prettier-plugin-sort-imports'],
-    importOrder: ['./global.css', '^react(.*)', '<THIRD_PARTY_MODULES>', '^[~/]', '^[./]'],
+    importOrder: ['<BUILTIN_MODULES>', '^react(.*)', '<THIRD_PARTY_MODULES>', '^[~/]', '^[./]'],
+    importOrderSideEffects: false,
     importOrderSeparation: true,
     importOrderSortSpecifiers: true,
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,7 +7,7 @@ module.exports = {
 
     plugins: ['@trivago/prettier-plugin-sort-imports'],
     importOrder: ['<BUILTIN_MODULES>', '^react(.*)', '<THIRD_PARTY_MODULES>', '^[~/]', '^[./]'],
-    importOrderSideEffects: false,
+    importOrderSideEffects: false, // TODO: Fix the side-effect import order issue and remove this option.
     importOrderSeparation: true,
     importOrderSortSpecifiers: true,
 };

--- a/apps/website/src/app/playground/_components/radio-button-group/radio-button-group.tsx
+++ b/apps/website/src/app/playground/_components/radio-button-group/radio-button-group.tsx
@@ -47,7 +47,9 @@ type ButtonProps = ComponentProps<typeof Button> & RadioGroupItemProps;
 const RadioButton = forwardRef<ButtonRef, ButtonProps>(({ value, children, ...props }, ref) => {
     return (
         <RadioGroupItem asChild ref={ref} value={value} {...props}>
-            <Button variant="outline" stretch>{children}</Button>
+            <Button variant="outline" stretch>
+                {children}
+            </Button>
         </RadioGroupItem>
     );
 });

--- a/apps/website/src/app/playground/_components/theme-panel/theme-panel.tsx
+++ b/apps/website/src/app/playground/_components/theme-panel/theme-panel.tsx
@@ -11,7 +11,6 @@ import Radius from '../panel-radius';
 import Scaling from '../panel-scaling';
 import styles from './theme-panel.module.scss';
 
-
 const ThemePanel = () => {
     const [open, setOpen] = useState(true);
     const [isCopied, setIsCopied] = useState(false);

--- a/apps/website/src/app/playground/layout.tsx
+++ b/apps/website/src/app/playground/layout.tsx
@@ -1,7 +1,8 @@
+import '@vapor-ui/core/styles.css';
+
 import type { ReactNode } from 'react';
 
 import { ThemeProvider, ThemeScript, createThemeConfig } from '@vapor-ui/core';
-import '@vapor-ui/core/styles.css';
 import type { Metadata } from 'next';
 
 import { SiteNavBar } from '~/components/site-nav-bar/site-nav-bar';

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -1,23 +1,10 @@
-// @prettier-ignore
-// ⚠️ IMPORTANT: The import order is crucial to avoid circular dependencies.
-// 1. Define CSS layers (must be first)
 import './global-var.css';
-
-// 2. Global reset styles
 import './global.css';
 import './layers.css';
-
-// 3. Create CSS variable contract
 import './vars.css';
-
-// 4. Assign theme values (after the contract is created)
 import './theme.css';
-
-// 5. Utility styles
 import './sprinkles.css';
 import './mixins/foreground.css';
-
-
 import '../components/avatar/avatar.css';
 import '../components/badge/badge.css';
 import '../components/button/button.css';

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -1,3 +1,4 @@
+// NOTE: The import order is crucial to avoid circular dependencies between CSS files.
 import './global-var.css';
 import './global.css';
 import './layers.css';


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## Related Issues

<!-- Please add any related issue numbers or links. -->
<!-- e.g., Fixes #123 -->
<!-- e.g., Notion: Design System Meeting Notes -->

## Description of Changes

Currently, all Prettier CI tests are failing due to an import sort error in `styles/index.ts` within the core package. While this can be resolved by improving the tsup build configuration, this task has been delayed by other priorities.

As an immediate fix for the Prettier error, I have set the `importOrderSideEffects: false` option to ignore formatting for side-effect imports.

Since this modification is a temporary workaround, it would be beneficial to consider a more sustainable long-term solution. Briefly, I believe adopting next-generation linting tools like oxlint and biome could be a promising approach. For a comparison of these two tools, please refer to this [discussion](https://github.com/biomejs/biome/discussions/1281).

Here is a brief summary:

**Biome**
- `+` Aims to provide linting and formatting options not only for JS/TS but also for JSON, HTML, CSS, and more.
- `+` Appears to be maturing with the release of v2.0.
- `+` Supports configuration options for monorepos.
- `-` Although significantly faster than ESLint, it seems to be slower than Oslint due to differences in their operational mechanisms.
- `-` It is noted that some discrepancies may arise, as it does not directly migrate all of ESLint's options.

**Oxlint**
- `+` Offers even faster performance than Biome.
- `+` Has also reached its v1.0 release.
- `+` Also supports monorepo configurations.
- `-` Currently lacks sufficient support for formatter functionality.

<!-- Please provide a brief summary of the changes in this PR. -->
<!-- e.g., Added new Avatar component -->
<!-- e.g., Updated Color tokens to support dark mode -->
<!-- e.g., Fixed styles for the disabled state in the Input component -->

## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
