### PR TITLE
fix(dialog): add maxHeight to dialog content

### DIFF
--- a/packages/core/src/components/dialog/dialog.css.ts
+++ b/packages/core/src/components/dialog/dialog.css.ts
@@ -106,10 +106,10 @@ export const body = layerStyle('components', {
     paddingBlock: 0,
     paddingInline: vars.size.space['300'],
     width: '100%',
-    "@supports": {
-        "(max-height: 80svh)": {
+    '@supports': {
+        '(max-height: 80svh)': {
             maxHeight: '80svh',
-        }
+        },
     },
     maxHeight: '80vh',
     overflowY: 'auto',


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## Related Issues

No related Issues.

## Description of Changes

Add maxHeight for `Dialog.body` viewport limit.

<img width="1216" height="719" alt="Screenshot 2025-08-14 at 16-17-03 Vapor Design System Figma" src="https://github.com/user-attachments/assets/d520a6cf-9c07-4f68-bef2-42e5b4cfb316" />

## Screenshots

<img width="3850" height="1696" alt="image" src="https://github.com/user-attachments/assets/277b4757-52a8-43b8-bafd-485aa9702ca0" />

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
