### PR TITLE
fix(card): Fix Card component border overlap issues

### DIFF
--- a/.changeset/card-border-fix.md
+++ b/.changeset/card-border-fix.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+Fix Card component border overlap issues using lobotomized owl pattern

--- a/packages/core/src/components/card/card.css.ts
+++ b/packages/core/src/components/card/card.css.ts
@@ -1,3 +1,5 @@
+import { globalStyle } from '@vanilla-extract/css';
+
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
 
@@ -13,12 +15,6 @@ export const root = layerStyle('components', {
 
 export const header = layerStyle('components', {
     padding: `${vars.size.space[200]} ${vars.size.space[300]}`,
-
-    selectors: {
-        '&:not(:last-child)': {
-            borderBottom: `1px solid ${vars.color.border.normal}`,
-        },
-    },
 });
 
 export const body = layerStyle('components', {
@@ -27,10 +23,9 @@ export const body = layerStyle('components', {
 
 export const footer = layerStyle('components', {
     padding: `${vars.size.space[200]} ${vars.size.space[300]}`,
+});
 
-    selectors: {
-        '&:not(:first-child)': {
-            borderTop: `1px solid ${vars.color.border.normal}`,
-        },
-    },
+// Apply lobotomized owl pattern using globalStyle
+globalStyle(`${root} > * + *`, {
+    borderTop: `1px solid ${vars.color.border.normal}`,
 });

--- a/packages/core/src/components/card/card.css.ts
+++ b/packages/core/src/components/card/card.css.ts
@@ -12,9 +12,13 @@ export const root = layerStyle('components', {
 });
 
 export const header = layerStyle('components', {
-    borderBottom: `1px solid ${vars.color.border.normal}`,
-
     padding: `${vars.size.space[200]} ${vars.size.space[300]}`,
+
+    selectors: {
+        '&:not(:last-child)': {
+            borderBottom: `1px solid ${vars.color.border.normal}`,
+        },
+    },
 });
 
 export const body = layerStyle('components', {
@@ -22,7 +26,11 @@ export const body = layerStyle('components', {
 });
 
 export const footer = layerStyle('components', {
-    borderTop: `1px solid ${vars.color.border.normal}`,
-
     padding: `${vars.size.space[200]} ${vars.size.space[300]}`,
+
+    selectors: {
+        '&:not(:first-child)': {
+            borderTop: `1px solid ${vars.color.border.normal}`,
+        },
+    },
 });


### PR DESCRIPTION
## Related Issues
- No related issues

## Description of Changes
- Fixes border overlap issues in Card component by conditionally applying borders based on element
  position within the card layout.
- Problem

  - Footer-only cards showed double borders due to footer's borderTop overlapping with card root border
  - Header-only cards showed unnecessary bottom borders when no content followed
  - Border styling was applied unconditionally, causing visual inconsistencies

  Solution

  Updated card.css.ts to use CSS pseudo-selectors for conditional border application:

  - Header: Only shows borderBottom when :not(:last-child) (prevents unnecessary border when nothing
  follows)
  - Footer: Only shows borderTop when :not(:first-child) (prevents overlap with root border when first
  element)
  
  Of course. Here is a simple summary in English that you can use for your pull request.

-----
### Handling Header + Footer Border Overlap
~~**The Problem**~~
~~A 2px double border appears when a `Card.Header` is immediately followed by a `Card.Footer` because the header applies a `border-bottom` and the footer applies a `border-top`.~~

~~**Chosen Solution & Rationale**~~
~~Instead of implementing a complex CSS-only or component-level fix, we are accepting this minor visual issue for the following reasons:~~

~~1.  **It's an Edge Case**: The `Header` + `Footer` layout without a `Body` is rarely used. All common patterns (`Header`+`Body`, `Body`+`Footer`, etc.) work perfectly.~~
~~2.  **Simplicity & Maintainability**: A proper fix would require complex, brittle CSS selectors or architectural changes (like using Context or prop drilling) that add unnecessary complexity for a minor issue. The current approach keeps the component's CSS clean and predictable.~~
~~3.  **Impact vs. Effort**: The effort to fix this 5% edge case outweighs the benefit, as it would compromise the simplicity and maintainability of the component for the 95% of common use cases.~~

~~**Workarounds for Developers**~~
~~If this specific layout is needed, developers can use one of these simple workarounds:~~


~~This approach prioritizes practical usability and developer experience over theoretical perfection. ~~
## Screenshots
- before
<img width="1362" height="619" alt="Screenshot 2025-08-18 at 18 06 53" src="https://github.com/user-attachments/assets/6f623fd4-3027-411e-81c8-1c339a99020a" />
- after
<img width="979" height="447" alt="Screenshot 2025-08-18 at 20 28 25" src="https://github.com/user-attachments/assets/c4238f8b-ddab-4569-b378-6928861b566f" />

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [x] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
