### PR TITLE
refactor: remove all label components

### DIFF
--- a/packages/core/src/components/checkbox/checkbox.css.ts
+++ b/packages/core/src/components/checkbox/checkbox.css.ts
@@ -2,8 +2,6 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { interaction } from '~/styles/mixins/interactions.css';
-import { typography } from '~/styles/mixins/typography.css';
-import { visuallyHidden } from '~/styles/mixins/visually-hidden.css';
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
 
@@ -19,20 +17,6 @@ export const root = recipe({
     variants: {
         disabled: {
             true: layerStyle('components', { opacity: 0.32, pointerEvents: 'none' }),
-        },
-    },
-});
-
-export const label = recipe({
-    base: [
-        typography({ style: 'body2' }),
-        layerStyle('components', { color: vars.color.foreground.normal }),
-    ],
-
-    defaultVariants: { visuallyHidden: false },
-    variants: {
-        visuallyHidden: {
-            true: visuallyHidden,
         },
     },
 });
@@ -113,4 +97,3 @@ export const indicator = recipe({
 
 export type RootVariants = NonNullable<RecipeVariants<typeof root>>;
 export type ControlVariants = NonNullable<RecipeVariants<typeof control>>;
-export type LabelVariants = NonNullable<RecipeVariants<typeof label>>;

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -43,7 +43,7 @@ export const Default: Story = {
                 <Text typography="heading3">Uncontrolled</Text>
                 <Checkbox.Root {...args}>
                     <Checkbox.Control />
-                    <Checkbox.Label>Default</Checkbox.Label>
+                    Default
                 </Checkbox.Root>
 
                 <br />
@@ -56,7 +56,7 @@ export const Default: Story = {
                     onCheckedChange={handleAllCheckedChange}
                 >
                     <Checkbox.Control />
-                    <Checkbox.Label>three meals a day</Checkbox.Label>
+                    three meals a day
                 </Checkbox.Root>
 
                 {checkboxItems.map((item) => (
@@ -69,7 +69,7 @@ export const Default: Story = {
                         }
                     >
                         <Checkbox.Control />
-                        <Checkbox.Label>{item.label}</Checkbox.Label>
+                        {item.label}
                     </Checkbox.Root>
                 ))}
             </Flex>
@@ -83,61 +83,56 @@ export const TestBed: Story = {
             <Flex style={{ gap: 'var(--vapor-size-dimension-100)', flexDirection: 'column' }}>
                 <Flex style={{ gap: 'var(--vapor-size-dimension-150)' }}>
                     <Checkbox.Root>
-                        <Checkbox.Label>Default</Checkbox.Label>
+                        Default
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root checked>
-                        <Checkbox.Label>Default checked</Checkbox.Label>
+                        Default checked
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root indeterminate>
-                        <Checkbox.Label>Default Indeterminate</Checkbox.Label>
+                        Default Indeterminate
                         <Checkbox.Control />
                     </Checkbox.Root>
                 </Flex>
 
                 <Flex style={{ gap: 'var(--vapor-size-dimension-150)' }}>
                     <Checkbox.Root disabled>
-                        <Checkbox.Label>Disabled</Checkbox.Label>
+                        Disabled
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root checked disabled>
-                        <Checkbox.Label>Disabled Checked</Checkbox.Label>
+                        Disabled Checked
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root indeterminate disabled>
-                        <Checkbox.Label>Disabled Indeterminate</Checkbox.Label>
+                        Disabled Indeterminate
                         <Checkbox.Control />
                     </Checkbox.Root>
                 </Flex>
 
                 <Flex style={{ gap: 'var(--vapor-size-dimension-150)' }}>
                     <Checkbox.Root invalid>
-                        <Checkbox.Label>Invalid</Checkbox.Label>
+                        Invalid
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root checked invalid>
-                        <Checkbox.Label>Invalid Checked</Checkbox.Label>
+                        Invalid Checked
                         <Checkbox.Control />
                     </Checkbox.Root>
                     <Checkbox.Root indeterminate invalid>
-                        <Checkbox.Label>Invalid Indeterminate</Checkbox.Label>
+                        Invalid Indeterminate
                         <Checkbox.Control />
                     </Checkbox.Root>
                 </Flex>
 
                 <Checkbox.Root size="md">
-                    <Checkbox.Label>MD</Checkbox.Label>
+                    MD
                     <Checkbox.Control />
                 </Checkbox.Root>
 
                 <Checkbox.Root size="lg">
-                    <Checkbox.Label>LG</Checkbox.Label>
-                    <Checkbox.Control />
-                </Checkbox.Root>
-
-                <Checkbox.Root visuallyHidden>
-                    <Checkbox.Label>Visually Hidden</Checkbox.Label>
+                    LG
                     <Checkbox.Control />
                 </Checkbox.Root>
             </Flex>

--- a/packages/core/src/components/checkbox/checkbox.test.tsx
+++ b/packages/core/src/components/checkbox/checkbox.test.tsx
@@ -21,15 +21,17 @@ describe('Checkbox', () => {
         });
 
         it('should have no a11y violations', async () => {
-            const rendered = render(<CheckboxTest />);
             const result = await axe(rendered.container);
 
             expect(result).toHaveNoViolations();
         });
 
-        it('should associate the label with the input field', () => {
-            const label = rendered.getByText(LABEL_TEXT) as HTMLLabelElement;
-            expect(label.htmlFor).toBe(checkbox.id);
+        it('should associate the label with the input field', async () => {
+            const label = rendered.getByLabelText(LABEL_TEXT);
+
+            await userEvent.click(label);
+
+            expect(checkbox).toHaveFocus();
         });
 
         it('should toggle checked state when clicked', async () => {
@@ -49,7 +51,7 @@ describe('Checkbox', () => {
         });
 
         it('should toggle checked state when label is clicked', async () => {
-            const label = rendered.getByText(LABEL_TEXT) as HTMLLabelElement;
+            const label = rendered.getByText(LABEL_TEXT);
             expect(checkbox).not.toBeChecked();
 
             await userEvent.click(label);
@@ -255,7 +257,7 @@ const LABEL_TEXT = 'Checkbox Label';
 const CheckboxTest = (props: CheckboxRootProps) => (
     <Checkbox.Root {...props}>
         <Checkbox.Control />
-        <Checkbox.Label>{LABEL_TEXT}</Checkbox.Label>
+        {LABEL_TEXT}
     </Checkbox.Root>
 );
 
@@ -274,7 +276,7 @@ const ControlledCheckboxTest = (props: CheckboxRootProps) => {
         <div>
             <Checkbox.Root {...props} checked={checkbox} onCheckedChange={handleCheckedChange}>
                 <Checkbox.Control />
-                <Checkbox.Label>{LABEL_TEXT} </Checkbox.Label>
+                {LABEL_TEXT}
             </Checkbox.Root>
 
             <button onClick={() => setBlocker((prev) => !prev)}>Blocker Controller</button>

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useId } from 'react';
+import { forwardRef } from 'react';
 
 import type { CheckedState } from '@radix-ui/react-checkbox';
 import { Indicator as RadixIndicator, Root as RadixRoot } from '@radix-ui/react-checkbox';
@@ -12,10 +12,10 @@ import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
 import type { VComponentProps } from '~/utils/types';
 
-import type { ControlVariants, LabelVariants, RootVariants } from './checkbox.css';
+import type { ControlVariants, RootVariants } from './checkbox.css';
 import * as styles from './checkbox.css';
 
-type CheckboxVariants = RootVariants & ControlVariants & LabelVariants;
+type CheckboxVariants = RootVariants & ControlVariants;
 type CheckboxSharedProps = CheckboxVariants & {
     checked?: boolean;
     onCheckedChange?: (checked: boolean) => void;
@@ -23,9 +23,7 @@ type CheckboxSharedProps = CheckboxVariants & {
     indeterminate?: boolean;
 };
 
-type CheckboxContext = CheckboxSharedProps & {
-    checkboxId?: string;
-};
+type CheckboxContext = CheckboxSharedProps;
 
 const [CheckboxProvider, useCheckboxContext] = createContext<CheckboxContext>({
     name: 'Checkbox',
@@ -37,11 +35,10 @@ const [CheckboxProvider, useCheckboxContext] = createContext<CheckboxContext>({
  * Checkbox.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveRootProps = VComponentProps<typeof Primitive.div>;
+type PrimitiveRootProps = VComponentProps<typeof Primitive.label>;
 interface CheckboxRootProps extends PrimitiveRootProps, CheckboxSharedProps {}
 
-const Root = forwardRef<HTMLDivElement, CheckboxRootProps>(({ className, ...props }, ref) => {
-    const checkboxId = useId();
+const Root = forwardRef<HTMLLabelElement, CheckboxRootProps>(({ className, ...props }, ref) => {
     const [checkboxProps, otherProps] = createSplitProps<CheckboxSharedProps>()(props, [
         'checked',
         'onCheckedChange',
@@ -50,14 +47,13 @@ const Root = forwardRef<HTMLDivElement, CheckboxRootProps>(({ className, ...prop
         'size',
         'invalid',
         'disabled',
-        'visuallyHidden',
     ]);
 
     const { disabled } = checkboxProps;
 
     return (
-        <CheckboxProvider value={{ checkboxId, ...checkboxProps }}>
-            <Primitive.div
+        <CheckboxProvider value={{ ...checkboxProps }}>
+            <Primitive.label
                 ref={ref}
                 className={clsx(styles.root({ disabled }), className)}
                 {...otherProps}
@@ -67,28 +63,6 @@ const Root = forwardRef<HTMLDivElement, CheckboxRootProps>(({ className, ...prop
 });
 Root.displayName = 'Checkbox.Root';
 
-/* -------------------------------------------------------------------------------------------------
- * Checkbox.Label
- * -----------------------------------------------------------------------------------------------*/
-
-type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
-interface CheckboxLabelProps extends PrimitiveLabelProps {}
-
-const Label = forwardRef<HTMLLabelElement, CheckboxLabelProps>(
-    ({ htmlFor, className, ...props }, ref) => {
-        const { checkboxId, visuallyHidden } = useCheckboxContext();
-
-        return (
-            <Primitive.label
-                ref={ref}
-                htmlFor={htmlFor || checkboxId}
-                className={clsx(styles.label({ visuallyHidden }), className)}
-                {...props}
-            />
-        );
-    },
-);
-
 /* ------------------------------------------------------------------------------------------------
  * Checkbox.Control
  * -----------------------------------------------------------------------------------------------*/
@@ -97,17 +71,9 @@ type ControlPrimitiveProps = VComponentProps<typeof RadixRoot>;
 interface CheckboxControlProps extends Omit<ControlPrimitiveProps, keyof CheckboxSharedProps> {}
 
 const Control = forwardRef<HTMLButtonElement, CheckboxControlProps>(
-    ({ id, className, ...props }, ref) => {
-        const {
-            checkboxId,
-            checked,
-            onCheckedChange,
-            defaultChecked,
-            indeterminate,
-            invalid,
-            disabled,
-            size,
-        } = useCheckboxContext();
+    ({ className, ...props }, ref) => {
+        const { checked, onCheckedChange, defaultChecked, indeterminate, invalid, disabled, size } =
+            useCheckboxContext();
 
         const [checkedState, setCheckedState] = useControllableState<CheckedState>({
             prop: indeterminate ? 'indeterminate' : checked,
@@ -122,7 +88,6 @@ const Control = forwardRef<HTMLButtonElement, CheckboxControlProps>(
         return (
             <RadixRoot
                 ref={ref}
-                id={checkboxId || id}
                 checked={checkedState}
                 onCheckedChange={setCheckedState}
                 disabled={disabled}
@@ -169,7 +134,7 @@ const DashIcon = (props: IconProps) => {
 
 /* -----------------------------------------------------------------------------------------------*/
 
-export { Root as CheckboxRoot, Label as CheckboxLabel, Control as CheckboxControl };
-export type { CheckedState, CheckboxRootProps, CheckboxLabelProps, CheckboxControlProps };
+export { Root as CheckboxRoot, Control as CheckboxControl };
+export type { CheckedState, CheckboxRootProps, CheckboxControlProps };
 
-export const Checkbox = { Root, Label, Control };
+export const Checkbox = { Root, Control };

--- a/packages/core/src/components/radio-group/radio-group.css.ts
+++ b/packages/core/src/components/radio-group/radio-group.css.ts
@@ -2,7 +2,6 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { interaction } from '~/styles/mixins/interactions.css';
-import { visuallyHidden } from '~/styles/mixins/visually-hidden.css';
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
 
@@ -102,25 +101,6 @@ export const indicator = layerStyle('components', {
     height: '50%',
 });
 
-export const label = recipe({
-    base: layerStyle('components', {
-        lineHeight: vars.typography.lineHeight['075'],
-
-        letterSpacing: vars.typography.letterSpacing['100'],
-        color: vars.color.foreground['normal'],
-        fontSize: vars.typography.fontSize['075'],
-        fontWeight: vars.typography.fontWeight[400],
-    }),
-
-    defaultVariants: { visuallyHidden: false },
-    variants: {
-        visuallyHidden: {
-            true: visuallyHidden,
-        },
-    },
-});
-
 export type RootVariants = NonNullable<RecipeVariants<typeof root>>;
 export type ItemVariants = NonNullable<RecipeVariants<typeof item>>;
 export type ControlVariants = NonNullable<RecipeVariants<typeof control>>;
-export type LabelVariants = NonNullable<RecipeVariants<typeof label>>;

--- a/packages/core/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/core/src/components/radio-group/radio-group.stories.tsx
@@ -27,23 +27,23 @@ export const Default: Story = {
         <RadioGroup.Root {...args}>
             <RadioGroup.Item value="1">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 1</RadioGroup.Label>
+                Item 1
             </RadioGroup.Item>
             <RadioGroup.Item value="2">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 2</RadioGroup.Label>
+                Item 2
             </RadioGroup.Item>
             <RadioGroup.Item value="3">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 3</RadioGroup.Label>
+                Item 3
             </RadioGroup.Item>
             <RadioGroup.Item value="4" invalid>
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 4 (Each Invalid)</RadioGroup.Label>
+                Item 4 (Each Invalid)
             </RadioGroup.Item>
             <RadioGroup.Item value="5" disabled>
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 5 (Each Disabled)</RadioGroup.Label>
+                Item 5 (Each Disabled)
             </RadioGroup.Item>
         </RadioGroup.Root>
     ),
@@ -54,23 +54,23 @@ export const TestBed: Story = {
         <RadioGroup.Root {...args} defaultValue="3">
             <RadioGroup.Item value="1">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 1</RadioGroup.Label>
+                Item 1
             </RadioGroup.Item>
             <RadioGroup.Item value="2">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 2</RadioGroup.Label>
+                Item 2
             </RadioGroup.Item>
             <RadioGroup.Item value="3">
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 3</RadioGroup.Label>
+                Item 3
             </RadioGroup.Item>
             <RadioGroup.Item value="4" invalid>
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 4 (Each Invalid)</RadioGroup.Label>
+                Item 4 (Each Invalid)
             </RadioGroup.Item>
             <RadioGroup.Item value="5" disabled>
                 <RadioGroup.Control />
-                <RadioGroup.Label>Item 5 (Each Disabled)</RadioGroup.Label>
+                Item 5 (Each Disabled)
             </RadioGroup.Item>
         </RadioGroup.Root>
     ),

--- a/packages/core/src/components/radio-group/radio-group.test.tsx
+++ b/packages/core/src/components/radio-group/radio-group.test.tsx
@@ -15,11 +15,11 @@ const RadioGroupTest = (props: RadioGroupRootProps) => {
         <RadioGroup.Root {...props}>
             <RadioGroup.Item value="option1">
                 <RadioGroup.Control />
-                <RadioGroup.Label>{OPTION_1}</RadioGroup.Label>
+                {OPTION_1}
             </RadioGroup.Item>
             <RadioGroup.Item value="option2">
                 <RadioGroup.Control />
-                <RadioGroup.Label>{OPTION_2}</RadioGroup.Label>
+                {OPTION_2}
             </RadioGroup.Item>
         </RadioGroup.Root>
     );
@@ -138,11 +138,11 @@ describe('RadioGroup', () => {
             >
                 <RadioGroup.Root name="radio-group-test">
                     <RadioGroup.Item value="a">
-                        <RadioGroup.Label>a</RadioGroup.Label>
+                        a
                         <RadioGroup.Control />
                     </RadioGroup.Item>
                     <RadioGroup.Item value="b">
-                        <RadioGroup.Label>b</RadioGroup.Label>
+                        b
                         <RadioGroup.Control />
                     </RadioGroup.Item>
                 </RadioGroup.Root>
@@ -169,15 +169,15 @@ describe('RadioGroup', () => {
             <RadioGroup.Root>
                 <RadioGroup.Item value="option1">
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option1</RadioGroup.Label>
+                    option1
                 </RadioGroup.Item>
                 <RadioGroup.Item value="option2">
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option2</RadioGroup.Label>
+                    option2
                 </RadioGroup.Item>
                 <RadioGroup.Item value="option3">
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option3</RadioGroup.Label>
+                    option3
                 </RadioGroup.Item>
             </RadioGroup.Root>,
         );
@@ -210,15 +210,15 @@ describe('RadioGroup', () => {
             <RadioGroup.Root>
                 <RadioGroup.Item value="option1">
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option1</RadioGroup.Label>
+                    option1
                 </RadioGroup.Item>
                 <RadioGroup.Item value="option2" disabled>
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option2</RadioGroup.Label>
+                    option2
                 </RadioGroup.Item>
                 <RadioGroup.Item value="option3">
                     <RadioGroup.Control />
-                    <RadioGroup.Label>option3</RadioGroup.Label>
+                    option3
                 </RadioGroup.Item>
             </RadioGroup.Root>,
         );

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ComponentPropsWithoutRef } from 'react';
-import { forwardRef, useId } from 'react';
+import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import {
@@ -15,7 +15,7 @@ import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
 import type { VComponentProps } from '~/utils/types';
 
-import type { ControlVariants, LabelVariants, RootVariants } from './radio-group.css';
+import type { ControlVariants, RootVariants } from './radio-group.css';
 import * as styles from './radio-group.css';
 
 type RadioGroupBaseProps = Pick<
@@ -23,7 +23,7 @@ type RadioGroupBaseProps = Pick<
     'name' | 'dir' | 'loop' | 'value' | 'onValueChange' | 'defaultValue' | 'required' | 'disabled'
 >;
 
-type RadioGroupVariants = RootVariants & ControlVariants & LabelVariants;
+type RadioGroupVariants = RootVariants & ControlVariants;
 type RadioGroupSharedProps = RadioGroupVariants & RadioGroupBaseProps;
 type RadioGroupContext = RadioGroupSharedProps;
 
@@ -54,7 +54,6 @@ const Root = forwardRef<HTMLDivElement, RadioGroupRootProps>(({ className, ...pr
 
     const [variantProps, otherProps] = createSplitProps<RadioGroupVariants>()(_otherProps, [
         'size',
-        'visuallyHidden',
         'orientation',
         'invalid',
     ]);
@@ -82,15 +81,13 @@ Root.displayName = 'RadioGroup.Root';
  * RadioGroup.Item
  * -----------------------------------------------------------------------------------------------*/
 
-type RadioGroupItemPrimitiveProps = VComponentProps<typeof Primitive.div>;
+type RadioGroupItemPrimitiveProps = VComponentProps<typeof Primitive.label>;
 type RadioGroupItemBaseProps = Pick<RadioGroupControlPrimitiveProps, 'value' | 'disabled'>;
 
-type RadioGroupItemVariants = ControlVariants & LabelVariants;
+type RadioGroupItemVariants = ControlVariants;
 type RadioGroupItemSharedProps = RadioGroupItemVariants & RadioGroupItemBaseProps;
 
-type RadioGroupItemContext = RadioGroupItemSharedProps & {
-    radioGroupItemId?: string;
-};
+type RadioGroupItemContext = RadioGroupItemSharedProps;
 
 const [RadioGroupItemProvider, useRadioGroupItemContext] = createContext<RadioGroupItemContext>({
     name: 'RadioGroupItem',
@@ -100,29 +97,21 @@ const [RadioGroupItemProvider, useRadioGroupItemContext] = createContext<RadioGr
 
 interface RadioGroupItemProps extends RadioGroupItemPrimitiveProps, RadioGroupItemSharedProps {}
 
-const Item = forwardRef<HTMLDivElement, RadioGroupItemProps>(({ className, ...props }, ref) => {
-    const radioGroupItemId = useId();
+const Item = forwardRef<HTMLLabelElement, RadioGroupItemProps>(({ className, ...props }, ref) => {
     const rootContext = useRadioGroupContext();
 
     const [itemProps, otherProps] = createSplitProps<RadioGroupItemSharedProps>()(props, [
         'value',
         'disabled',
-        'visuallyHidden',
         'size',
         'invalid',
     ]);
 
-    const {
-        disabled = rootContext.disabled,
-        invalid = rootContext.invalid,
-        visuallyHidden = rootContext.visuallyHidden,
-    } = itemProps;
+    const { disabled = rootContext.disabled, invalid = rootContext.invalid } = itemProps;
 
     return (
-        <RadioGroupItemProvider
-            value={{ ...itemProps, radioGroupItemId, disabled, invalid, visuallyHidden }}
-        >
-            <Primitive.div
+        <RadioGroupItemProvider value={{ ...itemProps, disabled, invalid }}>
+            <Primitive.label
                 ref={ref}
                 className={clsx(styles.item({ disabled }), className)}
                 {...otherProps}
@@ -141,14 +130,13 @@ interface RadioGroupControlProps
     extends Omit<RadioGroupControlPrimitiveProps, keyof RadioGroupItemSharedProps> {}
 
 const Control = forwardRef<HTMLButtonElement, RadioGroupControlProps>(
-    ({ id, className, ...props }, ref) => {
+    ({ className, ...props }, ref) => {
         const { size } = useRadioGroupContext();
-        const { radioGroupItemId, value, invalid, disabled } = useRadioGroupItemContext();
+        const { value, invalid, disabled } = useRadioGroupItemContext();
 
         return (
             <RadixItem
                 ref={ref}
-                id={id || radioGroupItemId}
                 value={value}
                 disabled={disabled}
                 aria-invalid={invalid}
@@ -162,42 +150,9 @@ const Control = forwardRef<HTMLButtonElement, RadioGroupControlProps>(
 );
 Control.displayName = 'RadioGroup.Control';
 
-/* -------------------------------------------------------------------------------------------------
- * RadioGroup.Label
- * -----------------------------------------------------------------------------------------------*/
-
-type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
-interface RadioGroupLabelProps extends Omit<PrimitiveLabelProps, keyof RadioGroupItemSharedProps> {}
-
-const Label = forwardRef<HTMLLabelElement, RadioGroupLabelProps>(
-    ({ htmlFor, className, ...props }, ref) => {
-        const { radioGroupItemId, visuallyHidden } = useRadioGroupItemContext();
-
-        return (
-            <Primitive.label
-                ref={ref}
-                htmlFor={htmlFor || radioGroupItemId}
-                className={clsx(styles.label({ visuallyHidden }), className)}
-                {...props}
-            />
-        );
-    },
-);
-Label.displayName = 'RadioGroup.Label';
-
 /* -----------------------------------------------------------------------------------------------*/
 
-export {
-    Root as RadioGroupRoot,
-    Item as RadioGroupItem,
-    Control as RadioGroupControl,
-    Label as RadioGroupLabel,
-};
-export type {
-    RadioGroupRootProps,
-    RadioGroupItemProps,
-    RadioGroupControlProps,
-    RadioGroupLabelProps,
-};
+export { Root as RadioGroupRoot, Item as RadioGroupItem, Control as RadioGroupControl };
+export type { RadioGroupRootProps, RadioGroupItemProps, RadioGroupControlProps };
 
-export const RadioGroup = { Root, Item, Control, Label };
+export const RadioGroup = { Root, Item, Control };

--- a/packages/core/src/components/switch/switch.css.ts
+++ b/packages/core/src/components/switch/switch.css.ts
@@ -2,7 +2,6 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { interaction } from '~/styles/mixins/interactions.css';
-import { visuallyHidden } from '~/styles/mixins/visually-hidden.css';
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
 
@@ -96,23 +95,5 @@ export const indicator = recipe({
     },
 });
 
-export const label = recipe({
-    base: layerStyle('components', {
-        lineHeight: vars.typography.lineHeight['075'],
-        letterSpacing: vars.typography.letterSpacing['100'],
-        color: vars.color.foreground['normal'],
-        fontSize: vars.typography.fontSize['075'],
-        fontWeight: vars.typography.fontWeight['400'],
-    }),
-
-    defaultVariants: { visuallyHidden: false },
-    variants: {
-        visuallyHidden: {
-            true: visuallyHidden,
-        },
-    },
-});
-
 export type RootVariants = NonNullable<RecipeVariants<typeof root>>;
 export type ControlVariants = NonNullable<RecipeVariants<typeof control>>;
-export type LabelVariants = NonNullable<RecipeVariants<typeof label>>;

--- a/packages/core/src/components/switch/switch.stories.tsx
+++ b/packages/core/src/components/switch/switch.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
         return (
             <Switch.Root {...args}>
                 <Switch.Control />
-                <Switch.Label>Default</Switch.Label>
+                Default
             </Switch.Root>
         );
     },
@@ -32,20 +32,15 @@ export const TestBed: Story = {
             <VStack gap="$150">
                 <Switch.Root size="sm">
                     <Switch.Control />
-                    <Switch.Label>Test Bed</Switch.Label>
+                    Test Bed
                 </Switch.Root>
                 <Switch.Root size="md">
                     <Switch.Control />
-                    <Switch.Label>Test Bed</Switch.Label>
+                    Test Bed
                 </Switch.Root>
                 <Switch.Root size="lg">
                     <Switch.Control />
-                    <Switch.Label>Test Bed</Switch.Label>
-                </Switch.Root>
-
-                <Switch.Root visuallyHidden>
-                    <Switch.Control />
-                    <Switch.Label>Test Bed</Switch.Label>
+                    Test Bed
                 </Switch.Root>
             </VStack>
         );

--- a/packages/core/src/components/switch/switch.test.tsx
+++ b/packages/core/src/components/switch/switch.test.tsx
@@ -14,12 +14,12 @@ describe('Switch', () => {
     describe('given a default Switch', () => {
         let rendered: RenderResult;
         let control: HTMLElement;
-        let label: HTMLLabelElement;
+        let label: HTMLElement;
 
         beforeEach(() => {
             rendered = render(<SwitchTest />);
             control = rendered.getByRole('switch');
-            label = rendered.getByText(LABEL_TEXT) as HTMLLabelElement;
+            label = rendered.getByText(LABEL_TEXT);
         });
 
         it('should have no a11y violations', async () => {
@@ -28,8 +28,12 @@ describe('Switch', () => {
             expect(result).toHaveNoViolations();
         });
 
-        it('should associate the label with the switch control', () => {
-            expect(label.htmlFor).toBe(control.id);
+        it('should associate the label with the switch control', async () => {
+            const label = rendered.getByLabelText(LABEL_TEXT);
+
+            await userEvent.click(label);
+
+            expect(control).toHaveFocus();
         });
 
         it('should toggle checked state when clicked', async () => {
@@ -191,7 +195,7 @@ const LABEL_TEXT = 'Test Switch';
 const SwitchTest = (props: SwitchRootProps) => (
     <Switch.Root {...props}>
         <Switch.Control />
-        <Switch.Label>{LABEL_TEXT}</Switch.Label>
+        {LABEL_TEXT}
     </Switch.Root>
 );
 
@@ -210,7 +214,7 @@ const ControlledSwitchTest = (props: SwitchRootProps) => {
         <>
             <Switch.Root {...props} checked={checked} onCheckedChange={handleCheckedChange}>
                 <Switch.Control />
-                <Switch.Label>{LABEL_TEXT}</Switch.Label>
+                {LABEL_TEXT}
             </Switch.Root>
 
             <button onClick={() => setBlocker((prev) => !prev)}>Blocker Controller</button>

--- a/packages/core/src/components/switch/switch.tsx
+++ b/packages/core/src/components/switch/switch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useId } from 'react';
+import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import { Thumb as RadixSwitchIndicator, Root as RadixSwitchRoot } from '@radix-ui/react-switch';
@@ -10,10 +10,10 @@ import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
 import type { VComponentProps } from '~/utils/types';
 
-import type { ControlVariants, LabelVariants, RootVariants } from './switch.css';
+import type { ControlVariants, RootVariants } from './switch.css';
 import * as styles from './switch.css';
 
-type SwitchVariants = RootVariants & ControlVariants & LabelVariants;
+type SwitchVariants = RootVariants & ControlVariants;
 
 type SwitchSharedProps = SwitchVariants & {
     checked?: boolean;
@@ -21,9 +21,7 @@ type SwitchSharedProps = SwitchVariants & {
     defaultChecked?: boolean;
 };
 
-type SwitchContext = SwitchSharedProps & {
-    switchId?: string;
-};
+type SwitchContext = SwitchSharedProps;
 
 const [SwitchProvider, useSwitchContext] = createContext<SwitchContext>({
     name: 'Switch',
@@ -35,25 +33,23 @@ const [SwitchProvider, useSwitchContext] = createContext<SwitchContext>({
  * Switch.Root
  * -----------------------------------------------------------------------------------------------*/
 
-type SwitchRootPrimitiveProps = VComponentProps<typeof Primitive.div>;
+type SwitchRootPrimitiveProps = VComponentProps<typeof Primitive.label>;
 interface SwitchRootProps extends SwitchRootPrimitiveProps, SwitchSharedProps {}
 
-const Root = forwardRef<HTMLDivElement, SwitchRootProps>(({ className, ...props }, ref) => {
-    const switchId = useId();
+const Root = forwardRef<HTMLLabelElement, SwitchRootProps>(({ className, ...props }, ref) => {
     const [switchProps, otherProps] = createSplitProps<SwitchSharedProps>()(props, [
         'checked',
         'onCheckedChange',
         'defaultChecked',
         'disabled',
         'size',
-        'visuallyHidden',
     ]);
 
     const { disabled } = switchProps;
 
     return (
-        <SwitchProvider value={{ switchId, ...switchProps }}>
-            <Primitive.div
+        <SwitchProvider value={{ ...switchProps }}>
+            <Primitive.label
                 ref={ref}
                 className={clsx(styles.root({ disabled }), className)}
                 {...otherProps}
@@ -64,29 +60,6 @@ const Root = forwardRef<HTMLDivElement, SwitchRootProps>(({ className, ...props 
 Root.displayName = 'Switch.Root';
 
 /* -------------------------------------------------------------------------------------------------
- * Switch.Label
- * -----------------------------------------------------------------------------------------------*/
-
-type SwitchLabelPrimitiveProps = VComponentProps<typeof Primitive.label>;
-interface SwitchLabelProps extends SwitchLabelPrimitiveProps {}
-
-const Label = forwardRef<HTMLLabelElement, SwitchLabelProps>(
-    ({ htmlFor, className, ...props }, ref) => {
-        const { switchId, visuallyHidden } = useSwitchContext();
-
-        return (
-            <Primitive.label
-                ref={ref}
-                htmlFor={htmlFor || switchId}
-                className={clsx(styles.label({ visuallyHidden }), className)}
-                {...props}
-            />
-        );
-    },
-);
-Label.displayName = 'Switch.Label';
-
-/* -------------------------------------------------------------------------------------------------
  * Switch.Control
  * -----------------------------------------------------------------------------------------------*/
 
@@ -94,14 +67,12 @@ type SwitchControlPrimitiveProps = VComponentProps<typeof RadixSwitchRoot>;
 interface SwitchControlProps extends Omit<SwitchControlPrimitiveProps, keyof SwitchSharedProps> {}
 
 const Control = forwardRef<HTMLButtonElement, SwitchControlProps>(
-    ({ id, className, ...props }, ref) => {
-        const { switchId, checked, onCheckedChange, defaultChecked, disabled, size } =
-            useSwitchContext();
+    ({ className, ...props }, ref) => {
+        const { checked, onCheckedChange, defaultChecked, disabled, size } = useSwitchContext();
 
         return (
             <RadixSwitchRoot
                 ref={ref}
-                id={id || switchId}
                 checked={checked}
                 defaultChecked={defaultChecked}
                 onCheckedChange={onCheckedChange}
@@ -118,7 +89,7 @@ Control.displayName = 'Switch.Control';
 
 /* -----------------------------------------------------------------------------------------------*/
 
-export { Root as SwitchRoot, Label as SwitchLabel, Control as SwitchControl };
-export type { SwitchRootProps, SwitchLabelProps, SwitchControlProps };
+export { Root as SwitchRoot, Control as SwitchControl };
+export type { SwitchRootProps, SwitchControlProps };
 
-export const Switch = { Root, Label, Control };
+export const Switch = { Root, Control };

--- a/packages/core/src/components/text-input/text-input.css.ts
+++ b/packages/core/src/components/text-input/text-input.css.ts
@@ -2,7 +2,6 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { interaction } from '~/styles/mixins/interactions.css';
-import { visuallyHidden } from '~/styles/mixins/visually-hidden.css';
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
 
@@ -24,22 +23,6 @@ export const root = recipe({
                 pointerEvents: 'none',
             },
         },
-    },
-});
-
-export const label = recipe({
-    base: layerStyle('components', {
-        lineHeight: vars.typography.lineHeight['050'],
-
-        letterSpacing: vars.typography.letterSpacing['000'],
-        color: vars.color.foreground['normal-lighter'],
-        fontSize: vars.typography.fontSize['050'],
-        fontWeight: vars.typography.fontWeight[500],
-    }),
-
-    defaultVariants: { visuallyHidden: false },
-    variants: {
-        visuallyHidden: { true: visuallyHidden },
     },
 });
 
@@ -100,5 +83,4 @@ export const field = recipe({
 });
 
 export type RootVariants = NonNullable<RecipeVariants<typeof root>>;
-export type LabelVariants = NonNullable<RecipeVariants<typeof label>>;
 export type FieldVariants = NonNullable<RecipeVariants<typeof field>>;

--- a/packages/core/src/components/text-input/text-input.stories.tsx
+++ b/packages/core/src/components/text-input/text-input.stories.tsx
@@ -7,7 +7,7 @@ import { Grid } from '../grid';
 
 export default {
     title: 'TextInput',
-    component: TextInput.Root,
+    component: TextInput,
     argTypes: {
         type: {
             control: 'inline-radio',
@@ -19,17 +19,12 @@ export default {
         readOnly: { control: 'boolean' },
         visuallyHidden: { control: 'boolean' },
     },
-} as Meta<typeof TextInput.Root>;
+} as Meta<typeof TextInput>;
 
-type Story = StoryObj<typeof TextInput.Root>;
+type Story = StoryObj<typeof TextInput>;
 
 export const Default: Story = {
-    render: (args) => (
-        <TextInput.Root placeholder="sadf" {...args}>
-            <TextInput.Label>레이블</TextInput.Label>
-            <TextInput.Field />
-        </TextInput.Root>
-    ),
+    render: (args) => <TextInput placeholder="sadf" {...args} />,
 };
 
 export const Controlled: Story = {
@@ -39,10 +34,7 @@ export const Controlled: Story = {
         return (
             <>
                 value: {value}
-                <TextInput.Root placeholder="sadf" value={value} onValueChange={setValue} {...args}>
-                    <TextInput.Label>레이블</TextInput.Label>
-                    <TextInput.Field />
-                </TextInput.Root>
+                <TextInput placeholder="sadf" value={value} onValueChange={setValue} {...args} />
             </>
         );
     },
@@ -51,40 +43,17 @@ export const Controlled: Story = {
 export const TestBed: Story = {
     render: (args) => (
         <Grid.Root templateRows="repeat(3, 1fr)" templateColumns="repeat(3, 1fr)" gap="$300">
-            <TextInput.Root placeholder="sadf" {...args}>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput placeholder="sadf" {...args} />
 
-            <TextInput.Root placeholder="sadf" {...args} disabled>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput placeholder="sadf" {...args} disabled />
 
-            <TextInput.Root placeholder="sadf" {...args} invalid>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput placeholder="sadf" {...args} invalid />
 
-            <TextInput.Root placeholder="sadf" {...args} readOnly>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput placeholder="sadf" {...args} readOnly />
 
-            <TextInput.Root placeholder="sadf" {...args} visuallyHidden>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput placeholder="sadf" {...args} />
 
-            <TextInput.Root placeholder="sadf" {...args}>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
-
-            <TextInput.Root value="value" placeholder="sadf" {...args}>
-                <TextInput.Label>Label</TextInput.Label>
-                <TextInput.Field />
-            </TextInput.Root>
+            <TextInput value="value" placeholder="sadf" {...args} />
         </Grid.Root>
     ),
 };

--- a/packages/core/src/components/text-input/text-input.test.tsx
+++ b/packages/core/src/components/text-input/text-input.test.tsx
@@ -2,15 +2,15 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'vitest-axe';
 
-import { TextInput, type TextInputRootProps } from './text-input';
+import { TextInput, type TextInputProps } from './text-input';
 
 const LABEL_TEXT = 'Label';
-const TextInputTest = (props: TextInputRootProps) => {
+const TextInputTest = (props: TextInputProps) => {
     return (
-        <TextInput.Root {...props}>
-            <TextInput.Label>{LABEL_TEXT}</TextInput.Label>
-            <TextInput.Field />
-        </TextInput.Root>
+        <label>
+            {LABEL_TEXT}
+            <TextInput {...props} />
+        </label>
     );
 };
 
@@ -22,12 +22,14 @@ describe('TextInput', () => {
         expect(result).toHaveNoViolations();
     });
 
-    it('should associate the label with the input field', () => {
+    it('should associate the label with the input field', async () => {
         const rendered = render(<TextInputTest />);
-        const label = rendered.getByText(LABEL_TEXT) as HTMLLabelElement;
+        const label = rendered.getByText(LABEL_TEXT);
         const input = rendered.getByRole('textbox');
 
-        expect(label.htmlFor).toBe(input.id);
+        await userEvent.click(label);
+
+        expect(input).toHaveFocus();
     });
 
     it('should invoke onValueChange when the input value changes', async () => {

--- a/packages/core/src/components/text-input/text-input.tsx
+++ b/packages/core/src/components/text-input/text-input.tsx
@@ -1,145 +1,58 @@
 'use client';
 
-import { forwardRef, useId } from 'react';
+import { forwardRef } from 'react';
 
 import { Primitive } from '@radix-ui/react-primitive';
 import clsx from 'clsx';
 
-import { createContext } from '~/libs/create-context';
 import { createSplitProps } from '~/utils/create-split-props';
 import type { VComponentProps } from '~/utils/types';
 
-import type { FieldVariants, LabelVariants, RootVariants } from './text-input.css';
+import type { FieldVariants, RootVariants } from './text-input.css';
 import * as styles from './text-input.css';
 
-type TextInputVariants = RootVariants & LabelVariants & FieldVariants;
-type TextInputSharedProps = TextInputVariants & {
+type Override<T, U> = Omit<T, keyof U> & Partial<U>;
+
+type TextInputVariants = RootVariants & FieldVariants;
+type BaseProps = TextInputVariants & {
     type?: 'text' | 'email' | 'password' | 'url' | 'tel' | 'search';
     value?: string;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
-    readOnly?: boolean;
-    placeholder?: string;
 };
-
-type TextInputContextType = TextInputSharedProps & {
-    textInputId?: string;
-};
-
-const [TextInputProvider, useTextInputContext] = createContext<TextInputContextType>({
-    name: 'TextInput',
-    hookName: 'useTextInputContext',
-    providerName: 'TextInputProvider',
-});
 
 /* -------------------------------------------------------------------------------------------------
  * TextInput
  * -----------------------------------------------------------------------------------------------*/
 
-type TextInputPrimitiveProps = VComponentProps<typeof Primitive.div>;
-interface TextInputRootProps extends TextInputPrimitiveProps, TextInputSharedProps {}
+type TextInputPrimitiveProps = VComponentProps<typeof Primitive.input>;
+interface TextInputProps extends Override<TextInputPrimitiveProps, BaseProps> {}
 
-const Root = forwardRef<HTMLDivElement, TextInputRootProps>(
-    ({ className, children, ...props }, ref) => {
-        const textInputId = useId();
-        const [textInputRootProps, otherProps] = createSplitProps<TextInputSharedProps>()(props, [
-            'type',
-            'value',
-            'onValueChange',
-            'defaultValue',
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+    ({ onValueChange, className, ...props }, ref) => {
+        const [textInputRootProps, otherProps] = createSplitProps<TextInputVariants>()(props, [
             'size',
             'disabled',
             'invalid',
-            'readOnly',
-            'visuallyHidden',
-            'placeholder',
         ]);
 
-        const { disabled } = textInputRootProps;
-
-        return (
-            <TextInputProvider value={{ textInputId, ...textInputRootProps }}>
-                <Primitive.div
-                    ref={ref}
-                    className={clsx(styles.root({ disabled }), className)}
-                    {...otherProps}
-                >
-                    {children}
-                </Primitive.div>
-            </TextInputProvider>
-        );
-    },
-);
-Root.displayName = 'TextInput.Root';
-
-/* -------------------------------------------------------------------------------------------------
- * TextInput.Label
- * -----------------------------------------------------------------------------------------------*/
-
-type PrimitiveLabelProps = VComponentProps<typeof Primitive.label>;
-interface TextInputLabelProps extends PrimitiveLabelProps {}
-
-const Label = forwardRef<HTMLLabelElement, TextInputLabelProps>(
-    ({ htmlFor, className, ...props }, ref) => {
-        const { textInputId = htmlFor, visuallyHidden } = useTextInputContext();
-
-        return (
-            <Primitive.label
-                ref={ref}
-                htmlFor={textInputId}
-                className={clsx(styles.label({ visuallyHidden }), className)}
-                {...props}
-            />
-        );
-    },
-);
-Label.displayName = 'TextInput.Label';
-
-/* -------------------------------------------------------------------------------------------------
- * TextInput.Field
- * -----------------------------------------------------------------------------------------------*/
-
-type PrimitiveInputProps = VComponentProps<typeof Primitive.input>;
-interface TextInputFieldProps extends Omit<PrimitiveInputProps, keyof TextInputSharedProps> {}
-
-const Field = forwardRef<HTMLInputElement, TextInputFieldProps>(
-    ({ id, className, ...props }, ref) => {
-        const {
-            type,
-            textInputId = id,
-            value,
-            onValueChange,
-            defaultValue,
-            disabled,
-            invalid,
-            readOnly,
-            size,
-            placeholder,
-        } = useTextInputContext();
+        const { disabled, invalid, size } = textInputRootProps;
 
         return (
             <Primitive.input
                 ref={ref}
-                id={textInputId}
-                type={type}
-                value={value}
-                onChange={(event) => onValueChange?.(event.target.value)}
-                defaultValue={defaultValue}
-                disabled={disabled}
                 aria-invalid={invalid}
-                readOnly={readOnly}
-                placeholder={placeholder}
+                disabled={disabled}
+                onChange={(event) => onValueChange?.(event.target.value)}
                 className={clsx(styles.field({ invalid, size }), className)}
-                {...props}
+                {...otherProps}
             />
         );
     },
 );
-Field.displayName = 'TextInput.Field';
+TextInput.displayName = 'TextInput';
 
 /* -----------------------------------------------------------------------------------------------*/
 
-export { Root as TextInputRoot, Label as TextInputLabel, Field as TextInputField };
-export type { TextInputRootProps, TextInputLabelProps, TextInputFieldProps };
-
-export const TextInput = { Root, Label, Field };
+export { TextInput };
+export type { TextInputProps };


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## Related Issues

<!-- Please add any related issue numbers or links. -->
<!-- e.g., Fixes #123 -->
<!-- e.g., Notion: Design System Meeting Notes -->

## Description of Changes

I've removed the Label component from the RadioGroup, TextInput, Switch, and Checkbox components. This change to the component interface required some updates to the test code. Please also review the UI changes that occurred as a result of removing the Label styles.

Here are a few other points to consider:

- Does it make sense for the difference between TextInput (a single component) and Switch/Checkbox (which are wrapped with a label) to be based simply on the default position of the label (top/bottom vs. left/right)?
- How will these components be combined with a future Field component, specifically with Field.Label?


## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [x] I have added tests for my changes.
- [x] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
