### PR TITLE
feat(TextInput): add Count sub-component with render props support

### DIFF
--- a/packages/core/src/components/text-input/text-input.css.ts
+++ b/packages/core/src/components/text-input/text-input.css.ts
@@ -1,7 +1,10 @@
+import { style } from '@vanilla-extract/css';
 import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { foregrounds } from '~/styles/mixins/foreground.css';
 import { interaction } from '~/styles/mixins/interactions.css';
+import { typography } from '~/styles/mixins/typography.css';
 import { visuallyHidden } from '~/styles/mixins/visually-hidden.css';
 import { layerStyle } from '~/styles/utils/layer-style.css';
 import { vars } from '~/styles/vars.css';
@@ -98,6 +101,16 @@ export const field = recipe({
         },
     },
 });
+
+export const count = style([
+    typography({ style: 'body3' }),
+    foregrounds({ color: 'hint' }),
+    layerStyle('components', {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+    }),
+]);
 
 export type RootVariants = NonNullable<RecipeVariants<typeof root>>;
 export type LabelVariants = NonNullable<RecipeVariants<typeof label>>;

--- a/packages/core/src/components/text-input/text-input.stories.tsx
+++ b/packages/core/src/components/text-input/text-input.stories.tsx
@@ -8,6 +8,10 @@ import { Grid } from '../grid';
 export default {
     title: 'TextInput',
     component: TextInput.Root,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
     argTypes: {
         type: {
             control: 'inline-radio',
@@ -18,6 +22,7 @@ export default {
         size: { control: 'inline-radio', options: ['sm', 'md', 'lg', 'xl'] },
         readOnly: { control: 'boolean' },
         visuallyHidden: { control: 'boolean' },
+        maxLength: { control: { type: 'number' } },
     },
 } as Meta<typeof TextInput.Root>;
 
@@ -25,8 +30,8 @@ type Story = StoryObj<typeof TextInput.Root>;
 
 export const Default: Story = {
     render: (args) => (
-        <TextInput.Root placeholder="sadf" {...args}>
-            <TextInput.Label>레이블</TextInput.Label>
+        <TextInput.Root placeholder="Enter your text here..." {...args}>
+            <TextInput.Label>Label</TextInput.Label>
             <TextInput.Field />
         </TextInput.Root>
     ),
@@ -34,16 +39,18 @@ export const Default: Story = {
 
 export const Controlled: Story = {
     render: (args) => {
-        const [value, setValue] = useState('');
+        const [value, setValue] = useState('Initial controlled value');
 
         return (
-            <>
-                value: {value}
-                <TextInput.Root placeholder="sadf" value={value} onValueChange={setValue} {...args}>
-                    <TextInput.Label>레이블</TextInput.Label>
-                    <TextInput.Field />
-                </TextInput.Root>
-            </>
+            <TextInput.Root
+                value={value}
+                onValueChange={setValue}
+                placeholder="This is a controlled text input..."
+                {...args}
+            >
+                <TextInput.Label>Label</TextInput.Label>
+                <TextInput.Field />
+            </TextInput.Root>
         );
     },
 };
@@ -51,39 +58,49 @@ export const Controlled: Story = {
 export const TestBed: Story = {
     render: (args) => (
         <Grid.Root templateRows="repeat(3, 1fr)" templateColumns="repeat(3, 1fr)" gap="$300">
-            <TextInput.Root placeholder="sadf" {...args}>
+            <TextInput.Root placeholder="Enter your text here..." {...args}>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root placeholder="sadf" {...args} disabled>
+            <TextInput.Root placeholder="Enter your text here..." {...args} disabled>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root placeholder="sadf" {...args} invalid>
+            <TextInput.Root placeholder="Enter your text here..." {...args} invalid>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root placeholder="sadf" {...args} readOnly>
+            <TextInput.Root placeholder="Enter your text here..." {...args} readOnly>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root placeholder="sadf" {...args} visuallyHidden>
+            <TextInput.Root placeholder="Enter your text here..." {...args} visuallyHidden>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root placeholder="sadf" {...args}>
+            <TextInput.Root placeholder="Enter your text here..." {...args}>
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
             </TextInput.Root>
 
-            <TextInput.Root value="value" placeholder="sadf" {...args}>
+            <TextInput.Root
+                defaultValue="Sample text content"
+                placeholder="Enter your text here..."
+                {...args}
+            >
                 <TextInput.Label>Label</TextInput.Label>
                 <TextInput.Field />
+            </TextInput.Root>
+
+            <TextInput.Root placeholder="Basic count..." maxLength={100} {...args}>
+                <TextInput.Label>Label</TextInput.Label>
+                <TextInput.Field />
+                <TextInput.Count />
             </TextInput.Root>
         </Grid.Root>
     ),


### PR DESCRIPTION
## Description of Changes

Added TextInput.Count sub-component that displays character count and maxLength, following the same patterns as the existing Textarea.Count component.

### Key Features
- **Character counting**: Real-time display of current character count
- **MaxLength integration**: Shows current/max format when maxLength is provided  
- **Render props support**: Customizable rendering via children function
- **Controlled/Uncontrolled patterns**: Works with both controlled and uncontrolled TextInput components
- **Event-driven updates**: Real-time updates for uncontrolled components via DOM event listeners
- **Design system integration**: Uses existing typography and color tokens

### Implementation Details
- Added `maxLength` prop to TextInputSharedProps interface
- Added `textInputRef` to context for DOM access in uncontrolled patterns
- Implemented Count component with render props pattern: `({ current, max }) => ReactNode`
- Added CSS styling using design system tokens (body3 typography, hint color)
- Comprehensive test coverage for all usage scenarios
- Updated Storybook with examples showcasing different patterns

## Checklist

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [x] I have added tests for my changes.
- [x] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)