### PR TITLE
fix: Fix checkbox borderRadius sync error

### DIFF
--- a/.changeset/fluffy-sites-slide.md
+++ b/.changeset/fluffy-sites-slide.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+Fix checkbox borderRadius sync error

--- a/packages/core/src/components/checkbox/checkbox.css.ts
+++ b/packages/core/src/components/checkbox/checkbox.css.ts
@@ -22,6 +22,7 @@ export const root = recipe({
 
             backgroundColor: vars.color.background.canvas,
             padding: vars.size.space['000'],
+            overflow: 'hidden',
 
             selectors: {
                 '&[data-checked], &[data-indeterminate]': {
@@ -29,6 +30,9 @@ export const root = recipe({
                 },
 
                 // NOTE: Prevents interaction styles from being applied when hovering over the label of a disabled radio button.
+                '&::before': {
+                    borderRadius: '0',
+                },
                 '&:disabled::before': { opacity: 0 },
                 '&:disabled': { opacity: 0.32, pointerEvents: 'none' },
                 '&[data-readonly]': { backgroundColor: vars.color.gray['200'] },


### PR DESCRIPTION

## Related Issues

Fixes #206

## Description of Changes

- Change hover interaction pesudo class not to use borderRadius and set parent element `overflow: hidden`

## Screenshots

<img width="719" height="339" alt="Screenshot 2025-09-30 at 13-35-20 Checkbox - Test Bed ⋅ Storybook" src="https://github.com/user-attachments/assets/fdc5dae7-78dd-4705-9294-79fc8df83a96" />


## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
