### PR TITLE
docs: fix npm install command formatting in installation guide

### DIFF
--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -16,7 +16,7 @@ description: Vapor UI 설치를 위한 가이드.
 다음 중 하나의 패키지 매니저를 사용하여 Vapor UI를 설치하세요:
 
 ```package-install
-  npm install @vapor-ui/core@latest @vapor-ui/icons@latest
+npm install @vapor-ui/core@latest @vapor-ui/icons@latest
 ```
 
 ---


### PR DESCRIPTION
## Related Issues

N/A

## Description of Changes

- Fixed duplicate "npm install" text issue in the installation guide caused by extra whitespace in the command block.

## Screenshots

### Before

<img width="956" height="322" alt="Screenshot 2025-10-03 at 5 01 03 PM" src="https://github.com/user-attachments/assets/f542983a-1b06-4f68-871e-e65f114be955" />

### After

<img width="954" height="323" alt="Screenshot 2025-10-03 at 5 00 07 PM" src="https://github.com/user-attachments/assets/ebc7f683-e71e-4faf-8f87-696b04bb8ec2" />

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [] I have performed a self-code review.
- [ ] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
