### PR TITLE
refactor(core): Improve data attribute types

### DIFF
--- a/packages/core/src/utils/data-attributes.ts
+++ b/packages/core/src/utils/data-attributes.ts
@@ -6,7 +6,7 @@ type SingleDataAttrValue = string | number | boolean | null | undefined;
 
 type ReturnByValue<T> = T extends Falsy ? {} : DataAttr;
 
-export function createDataAttribute<T extends SingleDataAttrValue>(
+function createDataAttribute<T extends SingleDataAttrValue>(
     key: string,
     value: T,
 ): ReturnByValue<T> {


### PR DESCRIPTION
## Description of Changes

Improved type inference for `createDataAttribute` function using conditional types. The function now returns `{}` for nullish values and `DataAttr` for non-nullish values through generic type parameter.

- Changed return type from union to conditional type `ReturnByValue<T>`
- Simplified implementation by removing boolean-specific logic
- Better type safety with generic constraint


## screenshots

- before
<img width="502" height="89" alt="Screenshot 2025-10-23 at 17 59 48" src="https://github.com/user-attachments/assets/7a184cfa-8737-4076-a355-199e071338c8" />

- after
<img width="527" height="80" alt="Screenshot 2025-10-23 at 17 58 41" src="https://github.com/user-attachments/assets/f6d29024-ade5-46e2-8719-ec4e4e3f2ad1" />


## Checklist

- [x] The PR title follows the Conventional Commits convention
- [ ] I have added tests for my changes
- [ ] I have updated the Storybook or relevant documentation
- [ ] I have added a changeset for this change
- [x] I have performed a self-code review
- [x] I have followed the project's coding conventions and component patterns