### PR TITLE
docs: change `vapor-ui` packages versions with beta tag

### DIFF
--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -16,7 +16,7 @@ description: Vapor UI 설치를 위한 가이드.
 다음 중 하나의 패키지 매니저를 사용하여 Vapor UI를 설치하세요:
 
 ```package-install
-npm install @vapor-ui/core@latest @vapor-ui/icons@latest
+npm install @vapor-ui/core@beta @vapor-ui/icons@beta
 ```
 
 ---

--- a/apps/website/content/docs/getting-started/theming.mdx
+++ b/apps/website/content/docs/getting-started/theming.mdx
@@ -14,7 +14,7 @@ Vapor UI는 라이트 모드, 다크 모드, 그리고 시스템 설정에 동�
 먼저, Vapor UI 핵심 패키지를 설치해야 합니다.
 
 ```package-install
-npm install @vapor-ui/core@latest
+npm install @vapor-ui/core@beta
 ```
 
 ### 2. `ThemeProvider` 설정

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ Vapor UI core components library.
 
 ```bash
 # With npm
-npm install @vapor-ui/core@latest @vapor-ui/hooks@latest @vapor-ui/icons@latest
+npm install @vapor-ui/core@beta @vapor-ui/hooks@beta @vapor-ui/icons@beta
 ```
 
 ## License


### PR DESCRIPTION
## Description of Changes

- `latest` tag installs `1.0.0-beta.0`
- It should be installed `1.0.0-beta.3(recent number)
- Therefore, we have updated the documentation to use the beta tag instead of the latest tag during installation.

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
