### PR TITLE
docs: replace color prop references with colorPalette

### DIFF
--- a/apps/website/content/docs/components/badge.mdx
+++ b/apps/website/content/docs/components/badge.mdx
@@ -17,7 +17,7 @@ description: 'Badge는 이미지, 컨텐츠 등의 상태 또는 분류를 시�
 
 ---
 
-### Color
+### ColorPalette
 
 Badge 색상은 primary, success, warning, danger, contrast, hint 로 제공합니다.
 

--- a/apps/website/content/docs/components/button.mdx
+++ b/apps/website/content/docs/components/button.mdx
@@ -17,7 +17,7 @@ description: 'Button은 사용자가 주요 작업을 수행하도록 돕는 핵
 
 ---
 
-### Color
+### ColorPalette
 
 Button 색상은 primary, secondary, success, warning, danger, contrast 로 제공합니다.
 

--- a/apps/website/content/docs/components/callout.mdx
+++ b/apps/website/content/docs/components/callout.mdx
@@ -17,7 +17,7 @@ description: 'Callout은 중요한 정보를 시각적으로 강조하여 사용
 
 ---
 
-### Color
+### ColorPalette
 
 Callout 색상은 primary, success, warning, danger, hint, contrast 로 제공합니다.
 

--- a/apps/website/content/docs/components/icon-button.mdx
+++ b/apps/website/content/docs/components/icon-button.mdx
@@ -30,7 +30,7 @@ IconButton 사이즈는 sm, md, lg, xl 로 제공합니다.
 ```
 </Demo>
 
-### Color
+### ColorPalette
 
 IconButton 색상은 primary, secondary, success, warning, danger, contrast 로 제공합니다.
 

--- a/apps/website/public/components/badge.json
+++ b/apps/website/public/components/badge.json
@@ -1,7 +1,7 @@
 {
     "props": [
         {
-            "prop": "color",
+            "prop": "colorPalette",
             "type": ["primary", "hint", "danger", "success", "warning", "contrast"],
             "default": "primary",
             "description": "배지의 색상(의미)을 설정합니다. 예컨대 success는 성공 상태를, danger는 오류 상태를 나타냅니다."

--- a/apps/website/public/components/button.json
+++ b/apps/website/public/components/button.json
@@ -7,7 +7,7 @@
             "description": "버튼을 렌더링할 때 사용할 커스텀 렌더링 요소입니다."
         },
         {
-            "prop": "color",
+            "prop": "colorPalette",
             "type": ["primary", "secondary", "success", "warning", "danger", "contrast"],
             "default": "primary",
             "description": "버튼의 주 색상(의미)을 설정합니다."

--- a/apps/website/public/components/callout.json
+++ b/apps/website/public/components/callout.json
@@ -7,7 +7,7 @@
             "description": "Callout을 렌더링할 때 사용할 커스텀 렌더링 요소입니다."
         },
         {
-            "prop": "color",
+            "prop": "colorPalette",
             "type": ["primary", "success", "warning", "danger", "hint", "contrast"],
             "default": "primary",
             "description": "Callout의 색상을 설정합니다."

--- a/apps/website/public/components/icon-button.json
+++ b/apps/website/public/components/icon-button.json
@@ -7,7 +7,7 @@
             "description": "아이콘 버튼을 렌더링할 때 사용할 커스텀 렌더링 요소입니다."
         },
         {
-            "prop": "color",
+            "prop": "colorPalette",
             "type": ["primary", "secondary", "success", "warning", "danger", "contrast"],
             "default": "primary",
             "description": "아이콘 버튼의 주 색상(의미)을 설정합니다."


### PR DESCRIPTION
## Related Issues

#330

## Description of Changes

- Updated `Button`, `Badge`, `IconButton`, and `Callout` docs to reference the `colorPalette` prop.
- Synced props JSON data so the component props tables reflect `colorPalette`.
- Cleaned up code snippets and descriptions that still mentioned the old `color` prop.

## Screenshots

**e.g.,**
> <img width="899" height="599" alt="Screenshot 2025-11-07 at 9 39 11 AM" src="https://github.com/user-attachments/assets/62b2de4f-37e2-4536-9c56-da0d4968b4d1" />
> <img width="897" height="745" alt="Screenshot 2025-11-07 at 9 39 16 AM" src="https://github.com/user-attachments/assets/485b43a8-4fbb-490e-bad3-e6d6e9fa87d1" />

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [ ] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.