### PR TITLE
fix(scripts): remove ❤️ emoji prefix from figma icon extraction

### DIFF
--- a/scripts/syncFigmaIcons.mjs
+++ b/scripts/syncFigmaIcons.mjs
@@ -29,6 +29,11 @@ import getIconsIndex from './templates/icon/iconsIndex.js';
 
 const TYPE = process.env.TYPE;
 const CURRENT_DIRECTORY = process.cwd();
+const FIGMA_EMOJI_PREFIX_PATTERN = /❤️\s*/g;
+
+function normalizeIconName(name) {
+    return startCase(camelCase(name.replace(FIGMA_EMOJI_PREFIX_PATTERN, ''))).replace(/ /g, '');
+}
 
 console.log('\x1b[33m---------------- GDS FIGMA EXPORT -----------------\x1b[0m');
 
@@ -66,7 +71,7 @@ try {
 
     const componentsInfo = {
         total: components.length,
-        nameArr: components.map(({ name }) => startCase(camelCase(name.replace(/❤️\s*/g, ''))).replace(/ /g, '')),
+        nameArr: components.map(({ name }) => normalizeIconName(name)),
     };
     console.log(
         `\x1b[33m GDS FIGMA EXPORT: \x1b[0m ${componentsInfo.total} icons extraction complete`,
@@ -92,7 +97,7 @@ try {
     const newIconNameArr = [];
     const updatedIconNameArr = [];
     const promiseCreateIcons = componentsWithUrl.map(async ({ name, url, parentId }) => {
-        const iconName = startCase(camelCase(name.replace(/❤️\s*/g, ''))).replace(/ /g, '');
+        const iconName = normalizeIconName(name);
         const saveTargetPath = path.join(parentIconPath, iconName);
         const iconFilePath = path.resolve(saveTargetPath, `${iconName}.tsx`);
 


### PR DESCRIPTION
<!-- Please follow the Conventional Commits specification for the PR title. (e.g., feat(component): Add Button component)

All sections in this template are optional.
Feel free to remove sections that are not relevant to your pull request.
-->

## Related Issues

<!-- Please add any related issue numbers or links. -->
<!-- e.g., Fixes #123 -->
<!-- e.g., Notion: Design System Meeting Notes -->

N/A

## Description of Changes

<!-- Please provide a brief summary of the changes in this PR. -->
<!-- e.g., Added new Avatar component -->
<!-- e.g., Updated Color tokens to support dark mode -->
<!-- e.g., Fixed styles for the disabled state in the Input component -->

All icon components in Figma now have a ❤️ emoji prefix in their names.

Modified the Figma icon extraction script (`scripts/syncFigmaIcons.mjs`) to remove the ❤️ emoji prefix from icon component names during the extraction process.

## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

N/A

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
