### PR TITLE
fix(all): correct `gap` scale of list components

### DIFF
--- a/.changeset/tough-hotels-tickle.md
+++ b/.changeset/tough-hotels-tickle.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': patch
+---
+
+correct `gap` scale of list components

--- a/packages/core/src/components/menu/menu.css.ts
+++ b/packages/core/src/components/menu/menu.css.ts
@@ -49,7 +49,7 @@ export const item = componentStyle([
         alignItems: 'center',
         alignSelf: 'stretch',
         justifyContent: 'space-between',
-        gap: vars.size.space['100'],
+        gap: vars.size.space['050'],
 
         border: 'none',
 

--- a/packages/core/src/components/multi-select/multi-select.css.ts
+++ b/packages/core/src/components/multi-select/multi-select.css.ts
@@ -192,7 +192,7 @@ export const item = componentStyle([
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        gap: vars.size.space['100'],
+        gap: vars.size.space['050'],
 
         borderRadius: vars.size.borderRadius['300'],
 

--- a/packages/core/src/components/select/select.css.ts
+++ b/packages/core/src/components/select/select.css.ts
@@ -151,7 +151,7 @@ export const item = componentStyle([
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        gap: vars.size.space['100'],
+        gap: vars.size.space['050'],
 
         borderRadius: vars.size.borderRadius['300'],
 


### PR DESCRIPTION
## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Corrected spacing between items in menu, multi-select, and select components for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- correct `gap` from `100` to `050` from list components(`Select`, `MultiSelect`, `Menu`)

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
