### PR TITLE
docs: add JSDoc comments to Button, Avatar, and Dialog components

### DIFF
--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: write-component-jsdocs
+description: Guide for writing JSDoc comments on vapor-ui components and their props. Use when adding, reviewing, or fixing JSDoc on component tsx files or css.ts variant files. Covers where to place comments based on component pattern — standalone, compound root, compound sub-part — language and format rules, the @forwardedProps custom tag, and a checklist for review. Triggers on requests like add jsdocs, write component docs, document props, jsdoc 작성, or when reviewing a component documentation completeness.
+argument-hint: ComponentName — the PascalCase component name to document (e.g. Button, Dialog, Avatar). Required. When provided, locate the component under packages/core/src/components/{kebab-case-name}/ and apply this guide to those files only.
+---
+
+# JSDoc Component Guide
+
+JSDoc in vapor-ui is **user-facing UI**, not internal code comments. Write it for developers who encounter the component for the first time via documentation sites (Storybook Autodocs, etc.).
+
+## Core rules
+
+- **Language**: English only. No Korean in JSDoc blocks.
+- **Format**: Always leave the first line of every `/** ... */` block empty.
+- **Placement**: Write on the Props interface/type, not on the component function.
+
+## Where to write
+
+Placement depends on the component pattern. See [references/guide.md](references/guide.md) for detailed patterns and examples.
+
+| Target            | File                 | Location                                              |
+| ----------------- | -------------------- | ----------------------------------------------------- |
+| Component summary | `{component}.tsx`    | Above the component function                          |
+| Individual props  | `{component}.tsx`    | Inside the `interface` or namespace `Props`           |
+| Variant groups    | `{component}.css.ts` | On each variant key object inside `componentRecipe()` |
+
+**Do NOT write JSDoc on:**
+
+- Individual variant values (`sm`, `md`, `primary`, `fill`, etc.) — the variant key description is sufficient
+- `export type XxxVariants` — tooling derives this from the recipe automatically
+
+### Pattern quick-reference
+
+- **Standalone** — no JSDoc on namespace `Props` itself; write variant group docs in `componentRecipe()` in `.css.ts`
+- **Compound Root** (custom props via `interface`) — write on the `interface`, namespace wraps it
+- **Compound Root with context** (`Assign<…, Context>` pattern) — write only on custom props; mark forwarded props with `@forwardedProps`
+- **Compound sub-part** (`Omit<…, keyof Context>` pattern) — write only on remaining props
+
+## Component summary rules
+
+1. One single line — no line breaks inside the summary
+2. User perspective: what it is → when to use it
+3. No internal terms (`memoized`, `wrapper`, `token-based`, etc.)
+4. End with the rendered HTML element using backticks around the tag: `Renders a \`<button>\` element.`or`Doesn't render its own HTML element.`
+
+## Prop description rules
+
+1. Don't repeat the prop name or its type
+2. Describe side effects and interactions with other props
+3. For numeric props: include unit and valid range
+4. For event handlers: specify the exact trigger condition, not just "handler"
+5. Include the default value when relevant: `Default: \`false\``
+
+## `@forwardedProps` tag
+
+When a compound Root forwards props to sub-parts via Context, declare this so `ts-api-extractor` can pick them up:
+
+```tsx
+/**
+ * Avatar root component. Renders a <span> element.
+ *
+ * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
+ * @forwardedProps {AvatarFallbackPrimitive} delay
+ */
+export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>(...)
+```
+
+Syntax: `@forwardedProps {ComponentName} prop1 prop2 …`
+
+## Review checklist
+
+See the full checklist in [references/guide.md](references/guide.md#checklist).
+
+**Quick checklist:**
+
+- [ ] All JSDoc in English
+- [ ] First line of every block is empty
+- [ ] Summary is one line, complete sentence, HTML element in backticks (e.g. `` `<button>` ``)
+- [ ] No prop name repetition in descriptions
+- [ ] Event handlers describe exact trigger condition
+- [ ] Numeric props include unit and range
+- [ ] Compound Root with context has `@forwardedProps` tags
+- [ ] No JSDoc on individual variant values (`sm`, `md`, `fill`, `primary`, etc.)
+- [ ] No JSDoc on `export type XxxVariants`

--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -12,7 +12,7 @@ JSDoc in vapor-ui is **user-facing UI**, not internal code comments. Write it fo
 
 - **Language**: English only. No Korean in JSDoc blocks.
 - **Format**: Always leave the first line of every `/** ... */` block empty.
-- **Placement**: Write on the Props interface/type, not on the component function.
+- **Placement**: Write the component summary above the component function. Write individual prop descriptions inside the Props interface/type, not on the component function.
 
 ## Where to write
 

--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-component-jsdocs
-description: Guide for writing JSDoc comments on vapor-ui components and their props. Use when adding, reviewing, or fixing JSDoc on component tsx files or css.ts variant files. Covers where to place comments based on component pattern — standalone, compound root, compound sub-part — language and format rules, the @forwardedProps custom tag, and a checklist for review. Triggers on requests like add jsdocs, write component docs, document props, jsdoc 작성, or when reviewing a component documentation completeness.
+description: Guide for writing JSDoc comments on vapor-ui components and their props. Use when adding, reviewing, or fixing JSDoc on component tsx files or css.ts variant files. Covers where to place comments based on component pattern — standalone, compound root, compound sub-part — language and format rules, and a checklist for review. Triggers on requests like add jsdocs, write component docs, document props, jsdoc 작성, or when reviewing a component documentation completeness.
 argument-hint: ComponentName — the PascalCase component name to document (e.g. Button, Dialog, Avatar). Required. When provided, locate the component under packages/core/src/components/{kebab-case-name}/ and apply this guide to those files only.
 ---
 
@@ -33,7 +33,7 @@ Placement depends on the component pattern. See [references/guide.md](references
 
 - **Standalone** — no JSDoc on namespace `Props` itself; write variant group docs in `componentRecipe()` in `.css.ts`
 - **Compound Root** (custom props via `interface`) — write on the `interface`, namespace wraps it
-- **Compound Root with context** (`Assign<…, Context>` pattern) — write only on custom props; mark forwarded props with `@forwardedProps` above the namespace
+- **Compound Root with context** (`Assign<…, Context>` pattern) — write only on custom props
 - **Compound sub-part** (`Omit<…, keyof Context>` pattern) — write only on remaining props
 
 ## Component summary rules
@@ -51,25 +51,6 @@ Placement depends on the component pattern. See [references/guide.md](references
 4. For event handlers: specify the exact trigger condition, not just "handler"
 5. Include the default value when relevant: `Default: \`false\``
 
-## `@forwardedProps` tag
-
-When a compound Root forwards props to sub-parts via Context, declare this so `ts-api-extractor` can pick them up:
-
-```tsx
-/**
- * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
- * @forwardedProps {AvatarFallbackPrimitive} delay
- */
-export namespace AvatarRoot {
-    export type State = BaseAvatar.Root.State;
-    export type Props = AvatarRootProps;
-}
-```
-
-Syntax: `@forwardedProps {ComponentName} prop1 prop2 …`
-
-**Placement**: above the **component namespace** (`export namespace …`), not above the component function.
-
 ## Review checklist
 
 See the full checklist in [references/guide.md](references/guide.md#checklist).
@@ -82,6 +63,5 @@ See the full checklist in [references/guide.md](references/guide.md#checklist).
 - [ ] No prop name repetition in descriptions
 - [ ] Event handlers describe exact trigger condition
 - [ ] Numeric props include unit and range
-- [ ] Compound Root with context has `@forwardedProps` tags above the component namespace
 - [ ] No JSDoc on individual variant values (`sm`, `md`, `fill`, `primary`, etc.)
 - [ ] No JSDoc on `export type XxxVariants`

--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -33,7 +33,7 @@ Placement depends on the component pattern. See [references/guide.md](references
 
 - **Standalone** — no JSDoc on namespace `Props` itself; write variant group docs in `componentRecipe()` in `.css.ts`
 - **Compound Root** (custom props via `interface`) — write on the `interface`, namespace wraps it
-- **Compound Root with context** (`Assign<…, Context>` pattern) — write only on custom props; mark forwarded props with `@forwardedProps`
+- **Compound Root with context** (`Assign<…, Context>` pattern) — write only on custom props; mark forwarded props with `@forwardedProps` above the namespace
 - **Compound sub-part** (`Omit<…, keyof Context>` pattern) — write only on remaining props
 
 ## Component summary rules
@@ -57,15 +57,18 @@ When a compound Root forwards props to sub-parts via Context, declare this so `t
 
 ```tsx
 /**
- * Avatar root component. Renders a <span> element.
- *
  * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
  * @forwardedProps {AvatarFallbackPrimitive} delay
  */
-export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>(...)
+export namespace AvatarRoot {
+    export type State = BaseAvatar.Root.State;
+    export type Props = AvatarRootProps;
+}
 ```
 
 Syntax: `@forwardedProps {ComponentName} prop1 prop2 …`
+
+**Placement**: above the **component namespace** (`export namespace …`), not above the component function.
 
 ## Review checklist
 
@@ -79,6 +82,6 @@ See the full checklist in [references/guide.md](references/guide.md#checklist).
 - [ ] No prop name repetition in descriptions
 - [ ] Event handlers describe exact trigger condition
 - [ ] Numeric props include unit and range
-- [ ] Compound Root with context has `@forwardedProps` tags
+- [ ] Compound Root with context has `@forwardedProps` tags above the component namespace
 - [ ] No JSDoc on individual variant values (`sm`, `md`, `fill`, `primary`, etc.)
 - [ ] No JSDoc on `export type XxxVariants`

--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -41,7 +41,7 @@ Placement depends on the component pattern. See [references/guide.md](references
 1. One single line — no line breaks inside the summary
 2. User perspective: what it is → when to use it
 3. No internal terms (`memoized`, `wrapper`, `token-based`, etc.)
-4. End with the rendered HTML element using backticks around the tag: `Renders a \`<button>\` element.`or`Doesn't render its own HTML element.`
+4. End with the rendered HTML element using backticks around the tag: "Renders a `<button>` element.' or 'Doesn't render its own HTML element.".
 
 ## Prop description rules
 

--- a/.claude/skills/write-component-jsdocs/SKILL.md
+++ b/.claude/skills/write-component-jsdocs/SKILL.md
@@ -41,7 +41,7 @@ Placement depends on the component pattern. See [references/guide.md](references
 1. One single line — no line breaks inside the summary
 2. User perspective: what it is → when to use it
 3. No internal terms (`memoized`, `wrapper`, `token-based`, etc.)
-4. End with the rendered HTML element using backticks around the tag: "Renders a `<button>` element.' or 'Doesn't render its own HTML element.".
+4. End with the rendered HTML element using backticks around the tag: "Renders a `<button>` element." or "Doesn't render its own HTML element.".
 
 ## Prop description rules
 

--- a/.claude/skills/write-component-jsdocs/references/guide.md
+++ b/.claude/skills/write-component-jsdocs/references/guide.md
@@ -1,0 +1,416 @@
+# JSDoc Component Guide — Full Reference
+
+## Table of Contents
+
+1. [Where to write JSDoc](#where-to-write-jsdoc)
+2. [What appears on the documentation site](#what-appears-on-the-documentation-site)
+3. [Language](#language)
+4. [Format](#format)
+5. [Component summary](#component-summary)
+6. [Prop descriptions](#prop-descriptions)
+7. [@forwardedProps tag](#forwardedprops-tag)
+8. [Complete example](#complete-example)
+9. [Checklist](#checklist)
+
+---
+
+## Where to write JSDoc
+
+Placement depends on which component pattern is used.
+
+| Target                      | File                 | Location                                             |
+| --------------------------- | -------------------- | ---------------------------------------------------- |
+| Component Props             | `{component}.tsx`    | namespace `Props` type or the `interface` above it   |
+| Individual prop description | `{component}.tsx`    | Each property inside `interface` / namespace `Props` |
+| Variant groups              | `{component}.css.ts` | Each variant key object inside `componentRecipe()`   |
+
+**Do NOT write JSDoc on:**
+
+- Individual variant values (`sm`, `md`, `primary`, `fill`, etc.) — the group-level description is sufficient
+- `export type XxxVariants` — tooling derives this automatically from the recipe
+
+### Case 1 — Standalone: no JSDoc on namespace Props
+
+When the Props type is defined inline inside the namespace, do not write JSDoc on namespace `Props` itself. Write individual variant descriptions inside `componentRecipe()` in the `.css.ts` file.
+
+```ts
+// button.tsx — no JSDoc on Props
+export namespace Button {
+    export type State = BaseButton.State;
+    export type Props = VaporUIComponentProps<typeof BaseButton, State> & ButtonVariants;
+}
+
+// button.css.ts — write variant JSDoc here
+export const root = componentRecipe({
+    variants: {
+        /**
+         * Visual style of the button. Default: `'fill'`
+         */
+        variant: { fill: {}, outline: {}, ghost: {} },
+    },
+});
+```
+
+### Case 2 — Compound Root: write on the interface
+
+When custom props are defined via an `interface`, write JSDoc on the **interface**. The namespace wraps it.
+
+```ts
+// dialog.tsx
+export interface DialogRootProps
+    extends DialogVariants,
+        Omit<BaseDialog.Root.Props, 'disablePointerDismissal'> {
+    /**
+     * Closes the dialog when the overlay is clicked. Default: `true`
+     */
+    closeOnClickOverlay?: boolean;
+}
+
+export namespace DialogRoot {
+    export type State = {};
+    export type Props = DialogRootProps; // namespace wraps the interface
+    export type Actions = BaseDialog.Root.Actions;
+}
+```
+
+### Case 3 — Compound Root with Context: Assign pattern
+
+`Assign<VaporUIComponentProps, Context>` pattern. Write JSDoc only on custom props. Mark forwarded props with `@forwardedProps` (see section below).
+
+```ts
+// avatar.tsx
+export interface AvatarRootProps
+    extends Assign<VaporUIComponentProps<typeof BaseAvatar.Root, AvatarRoot.State>, AvatarContext> {
+    /**
+     * Custom image element to render inside the avatar.
+     */
+    imageElement?: ReactElement<AvatarImagePrimitive.Props>;
+}
+```
+
+### Case 4 — Compound sub-part: Omit pattern
+
+Props received from Context are excluded. Write JSDoc only on the remaining props.
+
+```ts
+// avatar.tsx
+export namespace AvatarImagePrimitive {
+    export type State = BaseAvatar.Image.State;
+    export type Props = Omit<
+        VaporUIComponentProps<typeof BaseAvatar.Image, State>,
+        keyof AvatarContext // context-provided props are excluded
+    >;
+}
+```
+
+---
+
+## What appears on the documentation site
+
+Tools differ in parsing scope but all expose these two:
+
+| Item              | Where it appears                          |
+| ----------------- | ----------------------------------------- |
+| Component Summary | Description text below the component name |
+| Prop descriptions | `description` column of the Props table   |
+
+**Not exposed**: implementation intent, algorithm comments, TODOs, internal team context. Put those in inline comments (`//`).
+
+---
+
+## Language
+
+**All JSDoc must be written in English.**
+
+The documentation site supports Korean and English, but the source is English. Korean translation is handled by a separate pipeline. Do not write Korean inside JSDoc blocks.
+
+```tsx
+// ❌ Korean
+/**
+ * 사용자 인터랙션을 위한 버튼 컴포넌트.
+ */
+
+// ✅ English
+/**
+ * Button component for user interactions.
+ */
+```
+
+---
+
+## Format
+
+**Always leave the first line of every JSDoc block empty.**
+
+Do not write content on the line immediately after `/__`. Even single-line comments must use the multi-line form.
+
+```tsx
+// ❌ content on first line
+/** Button component for user interactions. */
+
+// ✅ first line is empty
+/**
+ * Button component for user interactions.
+ */
+```
+
+---
+
+## Component Summary
+
+The JSDoc block directly above the component declaration. It's the first thing a developer reads on the documentation site.
+
+### Rules
+
+**1. Write the summary on a single line**
+
+No line breaks inside the summary. Separate sentences with `.` only.
+
+```tsx
+/**
+ * Button component for user interactions. Use for primary actions such as form submission, dialog triggers, and navigation.
+ */
+export function Button(props: ButtonProps) { ... }
+```
+
+**2. Write for a developer who has never seen this component**
+
+- No internal system names, team slang, or implementation details.
+- Order: "what it is" → "when to use it".
+
+```tsx
+// ❌ implementation detail leaks
+/**
+ * Vapor UI token-based memoized button wrapper.
+ */
+
+// ✅ user perspective
+/**
+ * Button component for user interactions.
+ */
+```
+
+**3. Write complete sentences**
+
+Fragments read poorly when rendered as-is on the documentation site.
+
+```tsx
+// ❌ fragment
+/**
+ * Button
+ */
+
+// ✅ complete sentence
+/**
+ * Button component for user interactions.
+ */
+```
+
+**4. State the rendered HTML element**
+
+End the summary with the element the component renders by default. Wrap the HTML tag in backticks. For components that don't render their own HTML element (Providers, Context wrappers), say so explicitly.
+
+```tsx
+// renders a specific element
+/**
+ * Button component for user interactions. Renders a `<button>` element.
+ */
+
+// renders no HTML element of its own
+/**
+ * Provides theme context to its children. Doesn't render its own HTML element.
+ */
+```
+
+---
+
+## Prop Descriptions
+
+Write on each property inside the Props interface or type declaration. In TypeScript projects, write on the Props interface — not on the component function — for better tool compatibility.
+
+```tsx
+interface ButtonProps {
+    /**
+     * Text displayed on the button.
+     */
+    label: string;
+    /**
+     * Visual style of the button.
+     */
+    variant?: 'fill' | 'outline' | 'ghost';
+}
+```
+
+### Rules
+
+**1. Don't repeat the prop name**
+
+The type system already shows the name and type. Descriptions fill in what the type system cannot say.
+
+```tsx
+// ❌ repeats the name
+/**
+ * The label prop. String type.
+ */
+label: string;
+
+// ✅ adds information the type doesn't
+/**
+ * Text displayed on the button.
+ */
+label: string;
+```
+
+**2. Describe conditions and side effects**
+
+Explain what happens when the prop is set — especially when it interacts with other props.
+
+```tsx
+/**
+ * Disables the button, blocking all interactions and dimming its appearance. Automatically set to `true` when `loading` is `true`. Default: `false`
+ */
+disabled?: boolean;
+
+/**
+ * Shows a spinner and disables the button while `true`. Default: `false`
+ */
+loading?: boolean;
+```
+
+**3. Include unit, range, and allowed values for numeric props**
+
+```tsx
+/**
+ * Delay before auto-dismissing, in milliseconds. Set to `0` to disable auto-dismiss.
+ */
+autoCloseMs?: number;
+```
+
+**4. Specify the exact trigger condition for event handlers**
+
+Don't stop at "click handler" — say precisely when it fires.
+
+```tsx
+// ❌ vague
+/**
+ * Click handler.
+ */
+onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+
+// ✅ exact trigger
+/**
+ * Called when the button is clicked or activated via Enter or Space key.
+ */
+onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+```
+
+---
+
+## `@forwardedProps` Tag
+
+When a compound Root forwards props to sub-parts via Context, `ts-api-extractor` cannot infer which props go where. Use the `@forwardedProps` custom tag to declare this explicitly.
+
+### Syntax
+
+```tsx
+/**
+ * Avatar root component. Renders a <span> element.
+ *
+ * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
+ * @forwardedProps {AvatarFallbackPrimitive} delay
+ */
+export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>(...)
+```
+
+- `{ComponentName}`: the target sub-part component — braces separate it from the prop list
+- Remaining tokens: prop names forwarded to that component (space-separated)
+- Use multiple tags for multiple targets
+- Follows the `@param {type}` JSDoc convention
+
+### When to use
+
+Required when the Root creates a Context via `createContext` and sub-parts (`Image`, `Fallback`, etc.) consume props from it via `useContext`. Omitting it causes those props to be missing from API extraction.
+
+---
+
+## Complete Example
+
+```tsx
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    /**
+     * Text displayed on the button.
+     */
+    label: string;
+
+    /**
+     * Visual style of the button.
+     */
+    variant?: 'fill' | 'outline' | 'ghost';
+
+    /**
+     * Size of the button.
+     */
+    size?: 'sm' | 'md' | 'lg';
+
+    /**
+     * Disables the button, blocking all interactions. Automatically set to `true` when `loading` is `true`.
+     */
+    disabled?: boolean;
+
+    /**
+     * Shows a spinner and disables the button while `true`.
+     */
+    loading?: boolean;
+
+    /**
+     * Called when the button is clicked or activated via Enter or Space key.
+     */
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+/**
+ * Button component for user interactions. Use for primary actions such as form submission, dialog triggers, and navigation. Renders a <button> element.
+ */
+export function Button({ label, variant = 'fill', size = 'md', ...props }: ButtonProps) {
+    // ...
+}
+```
+
+---
+
+## Checklist
+
+**Language**
+
+- [ ] All JSDoc is written in English
+
+**Format**
+
+- [ ] Every JSDoc block has an empty first line
+
+**Summary**
+
+- [ ] Summary is a single line (no line breaks)
+- [ ] Summary is a complete sentence describing what the component is
+- [ ] No internal implementation terms (`memoized`, `wrapper`, `token`, etc.)
+- [ ] Rendered HTML element is stated with backtick-wrapped tag (``Renders a `<x>` element.`` or `Doesn't render its own HTML element.`)
+
+**Placement**
+
+- [ ] Standalone: no JSDoc on namespace `Props` itself (variant group docs go in `componentRecipe()` in `.css.ts`)
+- [ ] Compound Root (`interface extends …` pattern): JSDoc is on the interface, not the namespace
+- [ ] Variant groups: JSDoc is on the variant key object (e.g. `size: { … }`) in `{component}.css.ts`
+- [ ] No JSDoc on individual variant values (`sm`, `md`, `fill`, `primary`, etc.)
+- [ ] No JSDoc on `export type XxxVariants`
+
+**Props**
+
+- [ ] No prop description simply repeats the prop name or type
+- [ ] Numeric props include unit and valid range
+- [ ] Props that interact with other props describe that interaction
+- [ ] Event handlers describe the exact trigger condition
+
+**Compound components**
+
+- [ ] Root components that forward props via Context have `@forwardedProps` tags
+- [ ] Each `@forwardedProps` tag includes the target component name and the full prop list

--- a/.claude/skills/write-component-jsdocs/references/guide.md
+++ b/.claude/skills/write-component-jsdocs/references/guide.md
@@ -142,7 +142,7 @@ The documentation site supports Korean and English, but the source is English. K
 
 **Always leave the first line of every JSDoc block empty.**
 
-Do not write content on the line immediately after `/__`. Even single-line comments must use the multi-line form.
+Do not write content on the line immediately after `/**`. Even single-line comments must use the multi-line form.
 
 ```tsx
 // ❌ content on first line
@@ -369,7 +369,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 /**
- * Button component for user interactions. Use for primary actions such as form submission, dialog triggers, and navigation. Renders a <button> element.
+ * Button component for user interactions. Use for primary actions such as form submission, dialog triggers, and navigation. Renders a `<button>` element.
  */
 export function Button({ label, variant = 'fill', size = 'md', ...props }: ButtonProps) {
     // ...

--- a/.claude/skills/write-component-jsdocs/references/guide.md
+++ b/.claude/skills/write-component-jsdocs/references/guide.md
@@ -8,9 +8,8 @@
 4. [Format](#format)
 5. [Component summary](#component-summary)
 6. [Prop descriptions](#prop-descriptions)
-7. [@forwardedProps tag](#forwardedprops-tag)
-8. [Complete example](#complete-example)
-9. [Checklist](#checklist)
+7. [Complete example](#complete-example)
+8. [Checklist](#checklist)
 
 ---
 
@@ -75,7 +74,7 @@ export namespace DialogRoot {
 
 ### Case 3 — Compound Root with Context: Assign pattern
 
-`Assign<VaporUIComponentProps, Context>` pattern. Write JSDoc only on custom props. Mark forwarded props with `@forwardedProps` (see section below).
+`Assign<VaporUIComponentProps, Context>` pattern. Write JSDoc only on custom props.
 
 ```ts
 // avatar.tsx
@@ -306,36 +305,6 @@ onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 
 ---
 
-## `@forwardedProps` Tag
-
-When a compound Root forwards props to sub-parts via Context, `ts-api-extractor` cannot infer which props go where. Use the `@forwardedProps` custom tag to declare this explicitly.
-
-### Syntax
-
-```tsx
-/**
- * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
- * @forwardedProps {AvatarFallbackPrimitive} delay
- */
-export namespace AvatarRoot {
-    export type State = BaseAvatar.Root.State;
-    export type Props = AvatarRootProps;
-}
-```
-
-Place the `@forwardedProps` block **above the component namespace** (`export namespace …`), not above the component function.
-
-- `{ComponentName}`: the target sub-part component — braces separate it from the prop list
-- Remaining tokens: prop names forwarded to that component (space-separated)
-- Use multiple tags for multiple targets
-- Follows the `@param {type}` JSDoc convention
-
-### When to use
-
-Required when the Root creates a Context via `createContext` and sub-parts (`Image`, `Fallback`, etc.) consume props from it via `useContext`. Omitting it causes those props to be missing from API extraction.
-
----
-
 ## Complete Example
 
 ```tsx
@@ -415,5 +384,4 @@ export function Button({ label, variant = 'fill', size = 'md', ...props }: Butto
 
 **Compound components**
 
-- [ ] Root components that forward props via Context have `@forwardedProps` tags above the component namespace
-- [ ] Each `@forwardedProps` tag includes the target component name and the full prop list
+- [ ] Compound Root with context (`Assign<…, Context>` pattern): JSDoc written only on custom props, not on context-provided props

--- a/.claude/skills/write-component-jsdocs/references/guide.md
+++ b/.claude/skills/write-component-jsdocs/references/guide.md
@@ -314,13 +314,16 @@ When a compound Root forwards props to sub-parts via Context, `ts-api-extractor`
 
 ```tsx
 /**
- * Avatar root component. Renders a <span> element.
- *
  * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
  * @forwardedProps {AvatarFallbackPrimitive} delay
  */
-export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>(...)
+export namespace AvatarRoot {
+    export type State = BaseAvatar.Root.State;
+    export type Props = AvatarRootProps;
+}
 ```
+
+Place the `@forwardedProps` block **above the component namespace** (`export namespace …`), not above the component function.
 
 - `{ComponentName}`: the target sub-part component — braces separate it from the prop list
 - Remaining tokens: prop names forwarded to that component (space-separated)
@@ -412,5 +415,5 @@ export function Button({ label, variant = 'fill', size = 'md', ...props }: Butto
 
 **Compound components**
 
-- [ ] Root components that forward props via Context have `@forwardedProps` tags
+- [ ] Root components that forward props via Context have `@forwardedProps` tags above the component namespace
 - [ ] Each `@forwardedProps` tag includes the target component name and the full prop list

--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,5 @@ storybook-static
 # docs
 /.source/
 
-# AI Outputs
-.claude
-
 # Worktrees
 .worktrees

--- a/packages/core/src/components/avatar/avatar.css.ts
+++ b/packages/core/src/components/avatar/avatar.css.ts
@@ -21,6 +21,9 @@ export const root = componentRecipe({
 
     defaultVariants: { size: 'md', shape: 'square' },
     variants: {
+        /**
+         * Size of the avatar. Controls the width, height, and border radius. Default: `'md'`
+         */
         size: {
             sm: {
                 width: vars.size.dimension[300],
@@ -43,6 +46,9 @@ export const root = componentRecipe({
                 vars: { [radii]: vars.size.borderRadius[400] },
             },
         },
+        /**
+         * Shape of the avatar border radius. Default: `'square'`
+         */
         shape: {
             square: { borderRadius: radii },
             circle: { borderRadius: '50%' },
@@ -66,6 +72,9 @@ export const fallback = componentRecipe({
 
     defaultVariants: { size: 'md' },
     variants: {
+        /**
+         * Size of the fallback content. Controls the font size, line height, font weight, and letter spacing. Default: `'md'`
+         */
         size: {
             sm: {
                 fontSize: vars.typography.fontSize['050'],

--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -27,6 +27,12 @@ const [AvatarProvider, useAvatarContext] = createContext<AvatarContext>({
 
 /* -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Avatar component for displaying a user's profile image with an automatic initial-based fallback. Renders a `<span>` element.
+ *
+ * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
+ * @forwardedProps {AvatarFallbackPrimitive} delay
+ */
 export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>((props, ref) => {
     const { imageElement, fallbackElement, className, children, ...componentProps } =
         resolveStyles(props);
@@ -83,6 +89,9 @@ AvatarRoot.displayName = 'Avatar.Root';
  * Avatar.ImagePrimitive
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Image part of the avatar that renders the profile picture. Renders an `<img>` element.
+ */
 export const AvatarImagePrimitive = forwardRef<HTMLImageElement, AvatarImagePrimitive.Props>(
     (props, ref) => {
         const { className, ...componentProps } = resolveStyles(props);
@@ -120,6 +129,9 @@ AvatarImagePrimitive.displayName = 'Avatar.ImagePrimitive';
  * Avatar.FallbackPrimitive
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Fallback part of the avatar shown when the image fails to load or is not provided. Displays initials derived from the `alt` text. Renders a `<span>` element.
+ */
 export const AvatarFallbackPrimitive = forwardRef<HTMLSpanElement, AvatarFallbackPrimitive.Props>(
     (props, ref) => {
         const { className, style, children, ...componentProps } = resolveStyles(props);

--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -233,10 +233,6 @@ export interface AvatarRootProps extends Assign<
     fallbackElement?: ReactElement<AvatarFallbackPrimitive.Props>;
 }
 
-/**
- * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
- * @forwardedProps {AvatarFallbackPrimitive} delay
- */
 export namespace AvatarRoot {
     export type State = BaseAvatar.Root.State;
     export type Props = AvatarRootProps;

--- a/packages/core/src/components/avatar/avatar.tsx
+++ b/packages/core/src/components/avatar/avatar.tsx
@@ -29,9 +29,6 @@ const [AvatarProvider, useAvatarContext] = createContext<AvatarContext>({
 
 /**
  * Avatar component for displaying a user's profile image with an automatic initial-based fallback. Renders a `<span>` element.
- *
- * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
- * @forwardedProps {AvatarFallbackPrimitive} delay
  */
 export const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRoot.Props>((props, ref) => {
     const { imageElement, fallbackElement, className, children, ...componentProps } =
@@ -236,6 +233,10 @@ export interface AvatarRootProps extends Assign<
     fallbackElement?: ReactElement<AvatarFallbackPrimitive.Props>;
 }
 
+/**
+ * @forwardedProps {AvatarImagePrimitive} src alt crossOrigin decoding fetchPriority height loading referrerPolicy sizes srcSet width useMap onLoadingStatusChange
+ * @forwardedProps {AvatarFallbackPrimitive} delay
+ */
 export namespace AvatarRoot {
     export type State = BaseAvatar.Root.State;
     export type Props = AvatarRootProps;

--- a/packages/core/src/components/button/button.css.ts
+++ b/packages/core/src/components/button/button.css.ts
@@ -33,6 +33,9 @@ export const root = componentRecipe({
 
     defaultVariants: { colorPalette: 'primary', size: 'md', variant: 'fill' },
     variants: {
+        /**
+         * Size of the button, controlling height, padding, and typography. Default: `'md'`
+         */
         size: {
             sm: [
                 typography({ style: 'subtitle1' }),
@@ -68,6 +71,9 @@ export const root = componentRecipe({
             ],
         },
 
+        /**
+         * Color palette applied to the button. Controls the background, text, and border colors for all visual variants. Default: `'primary'`
+         */
         colorPalette: {
             primary: {
                 vars: {
@@ -125,6 +131,9 @@ export const root = componentRecipe({
             },
         },
 
+        /**
+         * Visual style of the button. Default: `'fill'`
+         */
         variant: {
             fill: {
                 backgroundColor: bg,

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -10,6 +10,9 @@ import type { VaporUIComponentProps } from '~/utils/types';
 import type { ButtonVariants } from './button.css';
 import * as styles from './button.css';
 
+/**
+ * Button component for triggering actions. Use for primary actions such as form submission, dialog triggers, and navigation. Renders a `<button>` element.
+ */
 export const Button = forwardRef<HTMLElement, Button.Props>((props, ref) => {
     const { className, ...componentProps } = resolveStyles(props);
     const [variantsProps, otherProps] = createSplitProps<ButtonVariants>()(componentProps, [

--- a/packages/core/src/components/dialog/dialog.css.ts
+++ b/packages/core/src/components/dialog/dialog.css.ts
@@ -60,6 +60,9 @@ export const popup = componentRecipe({
 
     defaultVariants: { size: 'md' },
     variants: {
+        /**
+         * Width of the dialog popup. Default: `'md'`
+         */
         size: {
             md: { width: '31.25rem' },
             lg: { width: '50rem' },

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -283,9 +283,6 @@ export interface DialogRootProps
     closeOnClickOverlay?: boolean;
 }
 
-/**
- * @forwardedProps {DialogPopupPrimitive} size
- */
 export namespace DialogRoot {
     export type State = {};
     export type Props = DialogRootProps;

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -28,6 +28,11 @@ const [DialogProvider, useDialogContext] = createContext<DialogContext>({
  * Dialog
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Root of the Dialog compound component. Manages open state and provides size context to sub-parts. Doesn't render its own HTML element.
+ *
+ * @forwardedProps {DialogPopupPrimitive} size
+ */
 export const DialogRoot = ({
     size,
     closeOnClickOverlay = true,
@@ -47,6 +52,9 @@ export const DialogRoot = ({
  * Dialog.PortalPrimitive
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Portal container that renders dialog content outside the normal DOM hierarchy. Renders a `<div>` element.
+ */
 export const DialogPortalPrimitive = forwardRef<HTMLDivElement, DialogPortalPrimitive.Props>(
     (props, ref) => {
         const componentProps = resolveStyles(props);
@@ -60,6 +68,9 @@ DialogPortalPrimitive.displayName = 'Dialog.PortalPrimitive';
  * Dialog.OverlayPrimitive
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Semi-transparent backdrop rendered behind the dialog popup. Renders a `<div>` element.
+ */
 export const DialogOverlayPrimitive = forwardRef<HTMLDivElement, DialogOverlayPrimitive.Props>(
     (props, ref) => {
         const { className, ...componentProps } = resolveStyles(props);
@@ -79,6 +90,9 @@ DialogOverlayPrimitive.displayName = 'Dialog.OverlayPrimitive';
  * Dialog.PopupPrimitive
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * The dialog panel itself, centered on screen. Size is controlled by the `size` prop on `Dialog.Root`. Renders a `<div>` element.
+ */
 export const DialogPopupPrimitive = forwardRef<HTMLDivElement, DialogPopupPrimitive.Props>(
     (props, ref) => {
         const { className, ...componentProps } = resolveStyles(props);
@@ -99,6 +113,9 @@ DialogPopupPrimitive.displayName = 'Dialog.PopupPrimitive';
  * Dialog.Popup
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Convenience wrapper that composes `Dialog.PortalPrimitive`, `Dialog.OverlayPrimitive`, and `Dialog.PopupPrimitive` into a single element. Use `portalElement` or `overlayElement` to replace individual parts. Renders a `<div>` element.
+ */
 export const DialogPopup = forwardRef<HTMLDivElement, DialogPopup.Props>(
     ({ portalElement, overlayElement, ...props }, ref) => {
         const popup = <DialogPopupPrimitive ref={ref} {...props} />;
@@ -130,6 +147,9 @@ DialogPopup.displayName = 'Dialog.Popup';
  * Dialog.Trigger
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Button that opens the dialog when activated. Renders a `<button>` element.
+ */
 export const DialogTrigger = forwardRef<HTMLButtonElement, DialogTrigger.Props>((props, ref) => {
     const componentProps = resolveStyles(props);
 
@@ -141,6 +161,9 @@ DialogTrigger.displayName = 'Dialog.Trigger';
  * Dialog.Close
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Button that closes the dialog when activated. Renders a `<button>` element.
+ */
 export const DialogClose = forwardRef<HTMLButtonElement, DialogClose.Props>((props, ref) => {
     const componentProps = resolveStyles(props);
 
@@ -152,6 +175,9 @@ DialogClose.displayName = 'Dialog.Close';
  * Dialog.Title
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Heading element that labels the dialog for assistive technologies. Renders an `<h2>` element.
+ */
 export const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitle.Props>((props, ref) => {
     const { className, ...componentProps } = resolveStyles(props);
 
@@ -165,6 +191,9 @@ DialogTitle.displayName = 'Dialog.Title';
  * Dialog.Description
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Paragraph that provides supplementary text for the dialog, linked to the dialog panel for assistive technologies. Renders a `<p>` element.
+ */
 export const DialogDescription = forwardRef<HTMLParagraphElement, DialogDescription.Props>(
     (props, ref) => {
         const { className, ...componentProps } = resolveStyles(props);
@@ -184,6 +213,9 @@ DialogDescription.displayName = 'Dialog.Description';
  * Dialog.Header
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Top section of the dialog, typically containing the title and a close button. Renders a `<div>` element.
+ */
 export const DialogHeader = forwardRef<HTMLDivElement, DialogHeader.Props>((props, ref) => {
     const { render, className, ...componentProps } = resolveStyles(props);
 
@@ -203,6 +235,9 @@ DialogHeader.displayName = 'Dialog.Header';
  * Dialog.Body
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Scrollable main content area of the dialog. Renders a `<div>` element.
+ */
 export const DialogBody = forwardRef<HTMLDivElement, DialogBody.Props>((props, ref) => {
     const { render, className, ...componentProps } = resolveStyles(props);
 
@@ -222,6 +257,9 @@ DialogBody.displayName = 'Dialog.Body';
  * Dialog.Footer
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Bottom section of the dialog, typically containing action buttons. Renders a `<div>` element.
+ */
 export const DialogFooter = forwardRef<HTMLDivElement, DialogFooter.Props>((props, ref) => {
     const { render, className, ...componentProps } = resolveStyles(props);
 
@@ -242,8 +280,7 @@ DialogFooter.displayName = 'Dialog.Footer';
 export interface DialogRootProps
     extends DialogVariants, Omit<BaseDialog.Root.Props, 'disablePointerDismissal'> {
     /**
-     * Determines whether the dialog should close on outside clicks.
-     * @default true
+     * When `true`, clicking the overlay closes the dialog. Default: `true`
      */
     closeOnClickOverlay?: boolean;
 }
@@ -273,11 +310,11 @@ export namespace DialogPopupPrimitive {
 
 export interface DialogPopupProps extends DialogPopupPrimitive.Props {
     /**
-     * A Custom element for Dialog.PortalPrimitive. If not provided, the default Dialog.PortalPrimitive will be rendered.
+     * Replaces the default `Dialog.PortalPrimitive`. Use to customise portal container behavior.
      */
     portalElement?: ReactElement<DialogPortalPrimitive.Props>;
     /**
-     * A Custom element for Dialog.OverlayPrimitive. If not provided, the default Dialog.OverlayPrimitive will be rendered.
+     * Replaces the default `Dialog.OverlayPrimitive`. Use to customise backdrop appearance or behavior.
      */
     overlayElement?: ReactElement<DialogOverlayPrimitive.Props>;
 }

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -30,8 +30,6 @@ const [DialogProvider, useDialogContext] = createContext<DialogContext>({
 
 /**
  * Root of the Dialog compound component. Manages open state and provides size context to sub-parts. Doesn't render its own HTML element.
- *
- * @forwardedProps {DialogPopupPrimitive} size
  */
 export const DialogRoot = ({
     size,
@@ -285,6 +283,9 @@ export interface DialogRootProps
     closeOnClickOverlay?: boolean;
 }
 
+/**
+ * @forwardedProps {DialogPopupPrimitive} size
+ */
 export namespace DialogRoot {
     export type State = {};
     export type Props = DialogRootProps;


### PR DESCRIPTION
## Summary

- We have established guidelines for adding component JSDocs and added a skill containing these guidelines.
- We have included sample JSDocs added in accordance with these guidelines.
- We have added standalone components (button) and compound patterns (avatar, dialog) as sample JSDocs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added standardized JSDoc authoring guides for component development.
  * Enhanced component documentation across the library for improved developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->