### PR TITLE
feat: add `pr-labels` workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ZeroChoi2781 @MaxLee-dev @noahchoii
+* @MaxLee-dev @noahchoii

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,6 +11,7 @@ on:
 permissions:
     pull-requests: write
     issues: write
+    contents: read
 
 # Prevent concurrent label updates on the same PR from racing
 concurrency:
@@ -22,126 +23,113 @@ jobs:
         name: Update PR status label
         runs-on: ubuntu-latest
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Extract CODEOWNERS
+              id: codeowners
+              uses: SvanBoxel/codeowners-action@v1
+              with:
+                  path: "./.github/CODEOWNERS"
+
             - name: Update status label based on event
               uses: actions/github-script@v7
+              env:
+                  CODEOWNERS_JSON: ${{ steps.codeowners.outputs.codeowners }}
               with:
                   script: |
-                      const STATUS_PREFIX = 'status:';
-                      const LABEL_WAITING_MAINTAINER = 'status: waiting for maintainer';
-                      const LABEL_WAITING_AUTHOR = 'status: waiting for author';
+                      const WAITING_MAINTAINER = 'status: waiting for maintainer';
+                      const WAITING_AUTHOR = 'status: waiting for author';
 
-                      const LABEL_COLORS = {
-                        [LABEL_WAITING_MAINTAINER]: 'e4e669',
-                        [LABEL_WAITING_AUTHOR]: '0075ca',
-                      };
+                      const repo = context.repo;
+                      const codeowners = parseCodeowners(process.env.CODEOWNERS_JSON);
 
-                      async function ensureLabelExists(labelName) {
-                        try {
-                          await github.rest.issues.getLabel({
-                            owner: context.repo.owner,
-                            repo: context.repo.repo,
-                            name: labelName,
-                          });
-                        } catch (e) {
-                          if (e.status === 404) {
-                            await github.rest.issues.createLabel({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              name: labelName,
-                              color: LABEL_COLORS[labelName] ?? 'ededed',
-                            });
-                            console.log(`Created label: "${labelName}"`);
-                          } else {
-                            throw e;
-                          }
-                        }
+                      const label = determineLabel(context, codeowners);
+                      if (!label) return;
+
+                      await replaceStatusLabel(label.prNumber, label.name);
+
+                      // --- Small functions, each doing one thing ---
+
+                      function parseCodeowners(json) {
+                        const map = JSON.parse(json || '{}');
+                        return [...new Set(
+                          Object.values(map).flat().map(o => o.replace(/^@/, ''))
+                        )];
                       }
 
-                      async function setStatusLabel(prNumber, newLabel) {
-                        await ensureLabelExists(newLabel);
-
-                        const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                        });
-
-                        for (const label of currentLabels) {
-                          if (label.name.startsWith(STATUS_PREFIX)) {
-                            try {
-                              await github.rest.issues.removeLabel({
-                                owner: context.repo.owner,
-                                repo: context.repo.repo,
-                                issue_number: prNumber,
-                                name: label.name,
-                              });
-                              console.log(`Removed label: "${label.name}"`);
-                            } catch (e) {
-                              console.warn(`Failed to remove label "${label.name}": ${e.message}`);
-                            }
-                          }
+                      function determineLabel({ eventName, payload }, codeowners) {
+                        if (eventName === 'pull_request_target') {
+                          return { prNumber: payload.pull_request.number, name: WAITING_MAINTAINER };
                         }
 
+                        const comment = extractComment(eventName, payload);
+                        if (!comment) return null;
+                        if (comment.isBot) return null;
+                        if (!codeowners.includes(comment.author)) return null;
+
+                        return parseLabelCommand(comment);
+                      }
+
+                      function extractComment(eventName, payload) {
+                        if (payload.comment?.user?.type === 'Bot') {
+                          return { isBot: true };
+                        }
+
+                        if (eventName === 'issue_comment') {
+                          if (!payload.issue.pull_request) return null;
+                          return {
+                            prNumber: payload.issue.number,
+                            body: payload.comment.body,
+                            author: payload.comment.user.login,
+                          };
+                        }
+
+                        if (eventName === 'pull_request_review_comment') {
+                          return {
+                            prNumber: payload.pull_request.number,
+                            body: payload.comment.body,
+                            author: payload.comment.user.login,
+                          };
+                        }
+
+                        return null;
+                      }
+
+                      function parseLabelCommand(comment) {
+                        const trimmed = comment.body.trim();
+
+                        if (/^\[review\]/i.test(trimmed)) {
+                          return { prNumber: comment.prNumber, name: WAITING_AUTHOR };
+                        }
+                        if (/^\[answer\]/i.test(trimmed)) {
+                          return { prNumber: comment.prNumber, name: WAITING_MAINTAINER };
+                        }
+
+                        return null;
+                      }
+
+                      async function replaceStatusLabel(prNumber, newLabel) {
+                        await removeCurrentStatusLabels(prNumber);
+                        await addLabel(prNumber, newLabel);
+                      }
+
+                      async function removeCurrentStatusLabels(prNumber) {
+                        const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                          ...repo, issue_number: prNumber,
+                        });
+
+                        const removals = labels
+                          .filter(l => l.name.startsWith('status:'))
+                          .map(l => github.rest.issues.removeLabel({
+                            ...repo, issue_number: prNumber, name: l.name,
+                          }));
+
+                        await Promise.all(removals);
+                      }
+
+                      async function addLabel(prNumber, name) {
                         await github.rest.issues.addLabels({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: prNumber,
-                          labels: [newLabel],
+                          ...repo, issue_number: prNumber, labels: [name],
                         });
-
-                        console.log(`Set label "${newLabel}" on PR #${prNumber}`);
-                      }
-
-                      const eventName = context.eventName;
-
-                      // PR opened/reopened → waiting for maintainer
-                      if (eventName === 'pull_request_target') {
-                        const pr = context.payload.pull_request;
-                        await setStatusLabel(pr.number, LABEL_WAITING_MAINTAINER);
-                        return;
-                      }
-
-                      // Bot comments must not trigger label changes
-                      const commentUser = context.payload.comment?.user;
-                      if (commentUser?.type === 'Bot') {
-                        console.log(`Bot comment by "${commentUser.login}". Skipping.`);
-                        return;
-                      }
-
-                      let prNumber, prAuthor, commentBody, commentAuthor;
-
-                      if (eventName === 'issue_comment') {
-                        // issue_comment fires on both issues and PRs — skip plain issues
-                        if (!context.payload.issue.pull_request) {
-                          console.log('Comment is on an issue (not a PR). Skipping.');
-                          return;
-                        }
-                        prNumber = context.payload.issue.number;
-                        prAuthor = context.payload.issue.user.login;
-                        commentBody = context.payload.comment.body;
-                        commentAuthor = context.payload.comment.user.login;
-                      } else if (eventName === 'pull_request_review_comment') {
-                        prNumber = context.payload.pull_request.number;
-                        prAuthor = context.payload.pull_request.user.login;
-                        commentBody = context.payload.comment.body;
-                        commentAuthor = context.payload.comment.user.login;
-                      }
-
-                      if (!commentBody) {
-                        console.log('Could not extract comment body. Skipping.');
-                        return;
-                      }
-
-                      const trimmed = commentBody.trim();
-                      const isReview = /^\[review\]/i.test(trimmed);
-                      const isAnswer = /^\[answer\]/i.test(trimmed);
-
-                      if (isReview && commentAuthor !== prAuthor) {
-                        // Reviewer left a [review] comment → PR author must respond
-                        await setStatusLabel(prNumber, LABEL_WAITING_AUTHOR);
-                      } else if (isAnswer && commentAuthor === prAuthor) {
-                        // PR author left an [answer] comment → maintainer must re-review
-                        await setStatusLabel(prNumber, LABEL_WAITING_MAINTAINER);
-                      } else {
-                        console.log('No matching prefix/author condition. Skipping.');
                       }

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -38,8 +38,8 @@ jobs:
                   CODEOWNERS_JSON: ${{ steps.codeowners.outputs.codeowners }}
               with:
                   script: |
-                      const WAITING_MAINTAINER = 'status: waiting for maintainer';
-                      const WAITING_AUTHOR = 'status: waiting for author';
+                      const AWAITING_REVIEW = 'status: awaiting review';
+                      const AWAITING_ANSWER = 'status: awaiting answer';
 
                       const repo = context.repo;
                       const codeowners = parseCodeowners(process.env.CODEOWNERS_JSON);
@@ -60,7 +60,7 @@ jobs:
 
                       function determineLabel({ eventName, payload }, codeowners) {
                         if (eventName === 'pull_request_target') {
-                          return { prNumber: payload.pull_request.number, name: WAITING_MAINTAINER };
+                          return { prNumber: payload.pull_request.number, name: AWAITING_REVIEW };
                         }
 
                         const comment = extractComment(eventName, payload);
@@ -100,10 +100,10 @@ jobs:
                         const trimmed = comment.body.trim();
 
                         if (/^\[review\]/i.test(trimmed)) {
-                          return { prNumber: comment.prNumber, name: WAITING_AUTHOR };
+                          return { prNumber: comment.prNumber, name: AWAITING_ANSWER };
                         }
                         if (/^\[answer\]/i.test(trimmed)) {
-                          return { prNumber: comment.prNumber, name: WAITING_MAINTAINER };
+                          return { prNumber: comment.prNumber, name: AWAITING_REVIEW };
                         }
 
                         return null;

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,4 +1,4 @@
-name: PR Review Status Labels
+name: PR Labels
 
 on:
     pull_request_target:

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,147 @@
+name: PR Review Status Labels
+
+on:
+    pull_request_target:
+        types: [opened, reopened]
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+
+permissions:
+    pull-requests: write
+    issues: write
+
+# Prevent concurrent label updates on the same PR from racing
+concurrency:
+    group: pr-status-${{ github.event.pull_request.number || github.event.issue.number }}
+    cancel-in-progress: true
+
+jobs:
+    update-status-label:
+        name: Update PR status label
+        runs-on: ubuntu-latest
+        steps:
+            - name: Update status label based on event
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const STATUS_PREFIX = 'status:';
+                      const LABEL_WAITING_MAINTAINER = 'status: waiting for maintainer';
+                      const LABEL_WAITING_AUTHOR = 'status: waiting for author';
+
+                      const LABEL_COLORS = {
+                        [LABEL_WAITING_MAINTAINER]: 'e4e669',
+                        [LABEL_WAITING_AUTHOR]: '0075ca',
+                      };
+
+                      async function ensureLabelExists(labelName) {
+                        try {
+                          await github.rest.issues.getLabel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            name: labelName,
+                          });
+                        } catch (e) {
+                          if (e.status === 404) {
+                            await github.rest.issues.createLabel({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              name: labelName,
+                              color: LABEL_COLORS[labelName] ?? 'ededed',
+                            });
+                            console.log(`Created label: "${labelName}"`);
+                          } else {
+                            throw e;
+                          }
+                        }
+                      }
+
+                      async function setStatusLabel(prNumber, newLabel) {
+                        await ensureLabelExists(newLabel);
+
+                        const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                        });
+
+                        for (const label of currentLabels) {
+                          if (label.name.startsWith(STATUS_PREFIX)) {
+                            try {
+                              await github.rest.issues.removeLabel({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                issue_number: prNumber,
+                                name: label.name,
+                              });
+                              console.log(`Removed label: "${label.name}"`);
+                            } catch (e) {
+                              console.warn(`Failed to remove label "${label.name}": ${e.message}`);
+                            }
+                          }
+                        }
+
+                        await github.rest.issues.addLabels({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          labels: [newLabel],
+                        });
+
+                        console.log(`Set label "${newLabel}" on PR #${prNumber}`);
+                      }
+
+                      const eventName = context.eventName;
+
+                      // PR opened/reopened → waiting for maintainer
+                      if (eventName === 'pull_request_target') {
+                        const pr = context.payload.pull_request;
+                        await setStatusLabel(pr.number, LABEL_WAITING_MAINTAINER);
+                        return;
+                      }
+
+                      // Bot comments must not trigger label changes
+                      const commentUser = context.payload.comment?.user;
+                      if (commentUser?.type === 'Bot') {
+                        console.log(`Bot comment by "${commentUser.login}". Skipping.`);
+                        return;
+                      }
+
+                      let prNumber, prAuthor, commentBody, commentAuthor;
+
+                      if (eventName === 'issue_comment') {
+                        // issue_comment fires on both issues and PRs — skip plain issues
+                        if (!context.payload.issue.pull_request) {
+                          console.log('Comment is on an issue (not a PR). Skipping.');
+                          return;
+                        }
+                        prNumber = context.payload.issue.number;
+                        prAuthor = context.payload.issue.user.login;
+                        commentBody = context.payload.comment.body;
+                        commentAuthor = context.payload.comment.user.login;
+                      } else if (eventName === 'pull_request_review_comment') {
+                        prNumber = context.payload.pull_request.number;
+                        prAuthor = context.payload.pull_request.user.login;
+                        commentBody = context.payload.comment.body;
+                        commentAuthor = context.payload.comment.user.login;
+                      }
+
+                      if (!commentBody) {
+                        console.log('Could not extract comment body. Skipping.');
+                        return;
+                      }
+
+                      const trimmed = commentBody.trim();
+                      const isReview = /^\[review\]/i.test(trimmed);
+                      const isAnswer = /^\[answer\]/i.test(trimmed);
+
+                      if (isReview && commentAuthor !== prAuthor) {
+                        // Reviewer left a [review] comment → PR author must respond
+                        await setStatusLabel(prNumber, LABEL_WAITING_AUTHOR);
+                      } else if (isAnswer && commentAuthor === prAuthor) {
+                        // PR author left an [answer] comment → maintainer must re-review
+                        await setStatusLabel(prNumber, LABEL_WAITING_MAINTAINER);
+                      } else {
+                        console.log('No matching prefix/author condition. Skipping.');
+                      }

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -2,11 +2,11 @@ name: PR Labels
 
 on:
     pull_request_target:
-        types: [opened, reopened]
+        types: [ opened, reopened ]
     issue_comment:
-        types: [created]
+        types: [ created ]
     pull_request_review_comment:
-        types: [created]
+        types: [ created ]
 
 permissions:
     pull-requests: write
@@ -15,7 +15,8 @@ permissions:
 
 # Prevent concurrent label updates on the same PR from racing
 concurrency:
-    group: pr-status-${{ github.event.pull_request.number || github.event.issue.number }}
+    group: pr-status-${{ github.event.pull_request.number ||
+        github.event.issue.number }}
     cancel-in-progress: true
 
 jobs:
@@ -26,23 +27,15 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Extract CODEOWNERS
-              id: codeowners
-              uses: SvanBoxel/codeowners-action@v1
-              with:
-                  path: "./.github/CODEOWNERS"
-
             - name: Update status label based on event
               uses: actions/github-script@v7
-              env:
-                  CODEOWNERS_JSON: ${{ steps.codeowners.outputs.codeowners }}
               with:
                   script: |
                       const AWAITING_REVIEW = 'status: awaiting review';
                       const AWAITING_ANSWER = 'status: awaiting answer';
 
                       const repo = context.repo;
-                      const codeowners = parseCodeowners(process.env.CODEOWNERS_JSON);
+                      const codeowners = parseCodeowners();
 
                       const label = determineLabel(context, codeowners);
                       if (!label) return;
@@ -51,11 +44,25 @@ jobs:
 
                       // --- Small functions, each doing one thing ---
 
-                      function parseCodeowners(json) {
-                        const map = JSON.parse(json || '{}');
-                        return [...new Set(
-                          Object.values(map).flat().map(o => o.replace(/^@/, ''))
-                        )];
+                      function parseCodeowners() {
+                        const owners = readCodeownersFile().split('\n')
+                          .filter(line => line.trim() && !line.startsWith('#'))
+                          .flatMap(line => line.trim().split(/\s+/).slice(1))
+                          .map(owner => owner.replace(/^@/, ''));
+
+                        return [...new Set(owners)];
+                      }
+
+                      function readCodeownersFile() {
+                        const fs = require('fs');
+                        const path = require('path');
+                        
+                        try {
+                          return fs.readFileSync(path.join(process.cwd(), '.github', 'CODEOWNERS'), 'utf-8');
+                        } catch {
+                          console.warn('CODEOWNERS file not found');
+                          return '';
+                        }
                       }
 
                       function determineLabel({ eventName, payload }, codeowners) {

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -75,7 +75,7 @@ jobs:
                         if (comment.isBot) return null;
                         if (!codeowners.includes(comment.author)) return null;
 
-                        return parseLabelCommand(comment);
+                        return parseLabelComment(comment);
                       }
 
                       function extractComment(eventName, payload) {
@@ -103,7 +103,7 @@ jobs:
                         return null;
                       }
 
-                      function parseLabelCommand(comment) {
+                      function parseLabelComment(comment) {
                         const trimmed = comment.body.trim();
 
                         if (/^\[review\]/i.test(trimmed)) {

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -17,7 +17,7 @@ permissions:
 concurrency:
     group: pr-status-${{ github.event.pull_request.number ||
         github.event.issue.number }}
-    cancel-in-progress: true
+    cancel-in-progress: false
 
 jobs:
     update-status-label:


### PR DESCRIPTION
## Description of Changes

"I’ve added a workflow to automatically update the PR status labels."

- Initial PR Creation: Adds the `status: waiting for maintainer` label.
- Reviewer Feedback: When a reviewer leaves a comment with the [review] prefix, the label changes to `status: waiting for author`.
- Author Response: When the assignee responds with the [answer] prefix, the label updates to `status: waiting for review`.

@coderabbitai code review

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that keeps pull request status labels up to date by interpreting reviewer/commenter commands, ensuring each PR displays a single clear "status:*" label.
  * Updated code ownership entries to reflect current reviewers and maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->