### PR TITLE
chore: use workspace TypeScript as language server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": "explicit"
     },
+    "js/ts.tsdk.path": "node_modules/typescript/lib",
     "json.schemas": [
         {
             "url": "https://cdn.jsdelivr.net/npm/tsup/schema.json",


### PR DESCRIPTION
## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration for TypeScript support in VS Code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1165" height="363" alt="스크린샷 2026-04-23 오후 3 58 26" src="https://github.com/user-attachments/assets/fabc72d8-bf4d-46e3-956c-3b388d9690df" />

- Previously, the IDE was displaying errors related to TypeScript v7 because it was using its own built-in version.
- Since our project globally uses version 5.9.x, these errors were unnecessary. To resolve this, I've configured the IDE to strictly use the TypeScript version installed in the project workspace.

## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
