### PR TITLE
chore(eslint-plugin-vapor): set testTimeout for TS program initialization

### DIFF
--- a/packages/eslint-plugin-vapor/src/rules/should-have-title-on-dialog.test.ts
+++ b/packages/eslint-plugin-vapor/src/rules/should-have-title-on-dialog.test.ts
@@ -97,57 +97,60 @@ describe('should-have-title-on-dialog', () => {
     });
 });
 
-function createTestEnv(code: string) {
-    const fileName = '/absolute/path/to/test.tsx';
-    const coreFileName = '/absolute/path/to/node_modules/@vapor-ui/core/index.d.ts';
+const TEST_FILE_NAME = '/absolute/path/to/test.tsx';
+const CORE_FILE_NAME = '/absolute/path/to/node_modules/@vapor-ui/core/index.d.ts';
+const CORE_FILE_CONTENT = `
+    export namespace Dialog {
+        export const Title: any;
+        export const Root: any;
+        export const Popup: any;
+    }
+`;
 
-    const compilerOptions: ts.CompilerOptions = {
-        jsx: ts.JsxEmit.React,
-        target: ts.ScriptTarget.ESNext,
-        moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    };
+const compilerOptions: ts.CompilerOptions = {
+    jsx: ts.JsxEmit.React,
+    target: ts.ScriptTarget.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+};
 
-    const host = ts.createCompilerHost(compilerOptions);
-    const originalReadFile = host.readFile;
-    const originalFileExists = host.fileExists;
+const documentRegistry = ts.createDocumentRegistry();
 
-    host.readFile = (f) => {
-        if (f === fileName) return code;
-        if (f === coreFileName) {
-            return `
-                export namespace Dialog {
-                    export const Title: any;
-                    export const Root: any;
-                    export const Popup: any;
-                }
-            `;
-        }
-        // Minimal lib.d.ts if requested? typescript usually loads them from disk.
-        return originalReadFile(f);
-    };
+let currentCode = '';
 
-    host.fileExists = (f) => {
-        if (f === fileName || f === coreFileName) return true;
-        return originalFileExists(f);
-    };
-
-    host.resolveModuleNames = (moduleNames) => {
-        return moduleNames.map((moduleName) => {
-            if (moduleName === '@vapor-ui/core') {
-                return {
-                    resolvedFileName: coreFileName,
-                    isExternalLibraryImport: true,
-                };
+const serviceHost: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [TEST_FILE_NAME, CORE_FILE_NAME],
+    getScriptVersion: (fileName) => (fileName === TEST_FILE_NAME ? currentCode : '0'),
+    getScriptSnapshot: (fileName) => {
+        if (fileName === TEST_FILE_NAME) return ts.ScriptSnapshot.fromString(currentCode);
+        if (fileName === CORE_FILE_NAME) return ts.ScriptSnapshot.fromString(CORE_FILE_CONTENT);
+        const text = ts.sys.readFile(fileName);
+        return text !== undefined ? ts.ScriptSnapshot.fromString(text) : undefined;
+    },
+    getCurrentDirectory: () => '/',
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: (opts) => ts.getDefaultLibFilePath(opts),
+    fileExists: (f) => f === TEST_FILE_NAME || f === CORE_FILE_NAME || ts.sys.fileExists(f),
+    readFile: (f) => {
+        if (f === TEST_FILE_NAME) return currentCode;
+        if (f === CORE_FILE_NAME) return CORE_FILE_CONTENT;
+        return ts.sys.readFile(f);
+    },
+    resolveModuleNames: (moduleNames) =>
+        moduleNames.map((name) => {
+            if (name === '@vapor-ui/core') {
+                return { resolvedFileName: CORE_FILE_NAME, isExternalLibraryImport: true };
             }
-            // For checking relative imports like import { Dialog } from './dialog'
-            return undefined; // Fail others
-        });
-    };
+            return undefined;
+        }),
+};
 
-    const program = ts.createProgram([fileName], compilerOptions, host);
+const languageService = ts.createLanguageService(serviceHost, documentRegistry);
+
+function createTestEnv(code: string) {
+    currentCode = code;
+    const program = languageService.getProgram()!;
     const checker = program.getTypeChecker();
-    const sourceFile = program.getSourceFile(fileName)!;
-
+    const sourceFile = program.getSourceFile(TEST_FILE_NAME)!;
     return { sourceFile, checker };
 }
 

--- a/packages/eslint-plugin-vapor/src/rules/should-have-title-on-dialog.test.ts
+++ b/packages/eslint-plugin-vapor/src/rules/should-have-title-on-dialog.test.ts
@@ -111,6 +111,8 @@ const compilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.React,
     target: ts.ScriptTarget.ESNext,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    noLib: true,
+    skipLibCheck: true,
 };
 
 const documentRegistry = ts.createDocumentRegistry();

--- a/packages/eslint-plugin-vapor/vitest.config.ts
+++ b/packages/eslint-plugin-vapor/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
-        testTimeout: 30000,
     },
 
     resolve: {

--- a/packages/eslint-plugin-vapor/vitest.config.ts
+++ b/packages/eslint-plugin-vapor/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
+        testTimeout: 30000,
     },
 
     resolve: {


### PR DESCRIPTION
## Summary

- Add `testTimeout: 30000` to `vitest.config.ts` in `eslint-plugin-vapor`
- TypeScript program initialization (`ts.createProgram`) in tests takes longer than the default 5s timeout under some environments; bumping the limit prevents flaky timeouts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test harness to use a shared TypeScript language service with virtualized type definitions and mocked core typings, simplifying and speeding up test setup while preserving existing test expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/goorm-dev/vapor-ui/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->