### PR TITLE
feat(website): add sitemap.xml and robots.txt

### DIFF
--- a/apps/website/src/app/robots.ts
+++ b/apps/website/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+import { SITE_URL } from '~/constants/domain';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+            disallow: '/preview/',
+        },
+        sitemap: `${SITE_URL}/sitemap.xml`,
+    };
+}

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+import { SITE_URL } from '~/constants/domain';
+import { source, themeSource } from '~/lib/source';
+
+export const revalidate = false;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    const staticRoutes = ['', '/theme/playground'];
+
+    const docsRoutes = source.getPages().map((page) => page.url);
+    const themeRoutes = themeSource.getPages().map((page) => page.url);
+
+    const paths = [...staticRoutes, ...docsRoutes, ...themeRoutes];
+
+    return paths.map((path) => ({
+        url: `${SITE_URL}${path}`,
+    }));
+}


### PR DESCRIPTION
## Summary

Generates `sitemap.xml` and `robots.txt` using Next.js App Router’s native metadata files. No external dependencies.

- `sitemap.ts`: Collects URLs from Fumadocs `source`/`themeSource` pages and static routes (`/`, `/theme/playground`). Uses the existing `SITE_URL` constant for the host.
- `robots.ts`: Blocks crawling of `/preview/` and specifies the sitemap path.

## Modified Files

- `apps/website/src/app/sitemap.ts`
- `apps/website/src/app/robots.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved site discoverability and search engine optimization by configuring crawler access policies to allow public content while restricting preview areas, generating an XML sitemap to help search engines efficiently discover and index all available pages, and establishing proper site metadata for enhanced search visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->