### PR TITLE
feat: add `vapor-unit-test` skills

### DIFF
--- a/.claude/skills/vapor-unit-test/SKILL.md
+++ b/.claude/skills/vapor-unit-test/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: vapor-unit-test
+description: >
+    vapor-ui 모노레포(`packages/*`)의 유닛 테스트를 **Vitest** + **React Testing Library** 컨벤션에 맞게 작성합니다.
+    다음과 같은 표현이 보이면 — 명시적 파일 경로/스킬 이름 호출이 없더라도 — 반드시 이 스킬을 사용하세요:
+    "테스트 추가해줘", "이 컴포넌트/hook/util 테스트 써줘", "유닛 테스트 작성", "test 좀 짜줘", "테스트 코드 작성",
+    "spec 파일 만들어줘", "`*.test.ts(x)` 추가", "`__tests__` 만들어", "커버리지 올려/보강해",
+    "snapshot 갱신", "테스트 실패 고쳐", "이 파일 테스트 리뷰해줘",
+    "write/add/generate/scaffold unit tests", "improve test coverage", "review tests".
+    기존 테스트 파일을 리뷰하거나 누락된 커버리지를 보충하는 작업에도 사용합니다.
+    React 컴포넌트, 커스텀 hook, 그리고 그 외 일반 JS/TS 파일(순수 함수, 변환기, 생성기, 린트 규칙 등) 모두를 다룹니다.
+---
+
+# Vapor Unit Test Skill
+
+vapor-ui 모노레포의 모든 유닛 테스트를 작성·리뷰합니다.
+
+## 무엇을 테스트하는가에 따라 가이드가 다릅니다
+
+작성 대상에 맞춰 references/ 안의 가이드 한 개를 골라 읽으세요. **전부 한꺼번에 로드하지 마세요.**
+
+| 대상 | 가이드 |
+| --- | --- |
+| React 컴포넌트 | `references/component-tests.md` |
+| React 커스텀 hook (`use*`) | `references/hook-tests.md` |
+| 그 외 일반 JS/TS 파일 (순수 함수, 변환기, 생성기, 린트 규칙 등) | `references/general-tests.md` |
+
+작성 전에 **반드시 대상 소스 파일을 먼저 읽으세요.** 무엇을 테스트할지, 무엇이 위임(delegation)이라 테스트가 불필요한지 판단하기 위해서입니다.
+
+## 작성 워크플로우
+
+1. **대상 소스 읽기** — 어떤 함수/컴포넌트/hook인지, 외부 라이브러리에 단순 위임하는지 자체 로직이 있는지 파악
+2. **레퍼런스 선택** — 위 표에서 적절한 references 파일 1개 읽기
+3. **테스트 케이스 작성** — 행복 경로 + 실패 경로 + 엣지 케이스를 모두 다룸
+4. **검증** — `pnpm test <파일경로>` 또는 `pnpm test:coverage` 통과 확인
+
+### TDD는 옵션
+
+이 스킬의 주된 목적은 **테스트 파일 작성 컨벤션**입니다. TDD를 강제하지 않습니다.
+
+- 구현이 이미 완료된 코드에 테스트를 추가하는 호출에서는 TDD 적용 불가 — 그 경우엔 컨벤션에 맞춰 테스트만 작성
+- 구현이 아직 없거나, 전체 작업 흐름을 관장하는 호출에서 TDD 적용이 가능한 상황이라면 red → green → refactor 순서로 진행 권장 — 검증 누락을 줄임
+
+## 모든 테스트에 공통인 규칙
+
+### 파일 위치
+
+- **단일 파일 테스트** → 그 파일 바로 옆에 **co-located**.
+  예: `useInterval.ts` → `useInterval.test.ts`, `stateful-props.ts` → `stateful-props.test.ts`,
+  컴포넌트는 컴포넌트 폴더 안에 — `packages/core/src/components/<name>/<name>.test.tsx`
+- **여러 파일을 가로지르는 통합 테스트나 공통 시나리오** → 해당 영역 루트의 `__tests__/` 폴더.
+  예: `packages/codemod/.../__tests__/<name>.test.ts`, `packages/color-generator/__tests__/snapshots.test.ts`
+
+"단일 파일이냐 / 전체 흐름이냐"가 판단 기준. 같은 패키지 안에서도 두 위치가 공존할 수 있음.
+
+### 외부 fixture 파일
+
+테스트가 외부 fixture(`.input.tsx`/`.output.tsx`, JSON 모킹 데이터, 큰 입력 스냅샷 등)를 사용하면 **테스트 파일과 같은 위치의 `__testfixtures__/` 하위 폴더**에 둡니다 (`__testfixtures__`는 jscodeshift 관례명, 다른 도메인도 동일 이름 사용).
+
+이유:
+- 소스 폴더에 fixture가 섞이면 본체 파일 식별이 어려워짐
+- fixture는 의도적으로 부분/구버전 코드인 경우가 많아 빌드·타입체크 글롭이 fixture를 잡으면 오탐 발생 → `__testfixtures__/`는 vitest/tsconfig 글롭에서 한 번에 제외하기 쉬움
+
+```
+<area>/
+├── target.ts
+├── target.test.ts
+└── __testfixtures__/
+    ├── case-a.input.tsx
+    └── case-a.output.tsx
+```
+
+현재 주 사용처는 codemod지만, 컴포넌트·hook·유틸에서도 외부 fixture가 필요해지면 동일 규칙 적용.
+
+### Imports
+
+Vitest는 `globals: true` 설정으로 동작합니다. 다음 식별자는 **import 하지 마세요** — 전역으로 제공됩니다.
+
+```ts
+describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi
+```
+
+`Mock` 등 타입만은 `import type { Mock } from 'vitest'`로 가져옵니다.
+
+### `it()` 네이밍
+
+`it ___` 문장이 완성되도록 작성합니다. `should ___` 형식과 평서 현재형(`returns ___`, `merges ___`, `fires ___`) 둘 다 허용. 한 파일 안에서는 한 형식으로 통일.
+
+```ts
+// should 형식
+it('should invoke the onClick handler when clicked', ...)
+it('should not change its state when disabled', ...)
+
+// 평서 현재형
+it('returns null when input is empty', ...)
+it('merges static className values', ...)
+it('fires the callback every interval', ...)
+```
+
+속성/속성+값을 언급할 때는 백틱으로 감쌉니다.
+
+```ts
+it('should have the `aria-required` attribute on the trigger', ...)
+it('should have `aria-expanded="true"` when open', ...)
+```
+
+`userEvent`, `axe`, async 동작을 다루는 콜백은 모두 `async`.
+
+### Mock 함수
+
+```ts
+const onChange = vi.fn();
+// 타입 강제가 필요할 때만 — props 시그니처에 맞춰야 하거나 `mockImplementation` 타입 추론이 안 될 때
+const onChange: Mock = vi.fn();
+
+expect(onChange).toHaveBeenCalledTimes(1);
+expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ value: 'a' }));
+expect(onChange).not.toHaveBeenCalled();
+```
+
+### 커버리지 목표
+
+**4개 지표 모두 80% 이상**: Statements, Lines, Branches, Functions.
+
+지표가 떨어지면 소스 파일을 다시 보고 "이 라인이 자체 로직인가, 외부 라이브러리에 단순 위임인가"를 판단하세요. 자체 로직 → 테스트 추가. 단순 위임 → 우선순위 낮춤.
+
+**단순 위임 판단 기준** — 함수 본문이 `return externalLib.foo(args)` 처럼 외부 호출 한 줄(+ 인자 그대로 전달)이면 위임. 분기, 인자 변환, 입력 검증, 반환값 가공 중 하나라도 있으면 자체 로직 → 테스트.
+
+### 시각적 변형은 테스트하지 않음
+
+`size`, `shape`, `variant`, `color` 같은 시각적 prop은 시각 회귀 테스트가 담당합니다. 유닛 테스트에서 다루지 마세요.
+
+## 깊이 들어가야 할 때
+
+- 컴포넌트 작성 중인데 query/state-assertion 패턴이 헷갈린다 → `references/component-tests.md`
+- hook의 비동기 상태 변경을 어떻게 검증하는지 모르겠다 → `references/hook-tests.md`
+- snapshot을 쓸지 명시적 assertion을 쓸지 판단 못 하겠다, 도메인 헬퍼를 어떻게 활용하는지 → `references/general-tests.md`
+- 풀 예시가 필요하다 → `references/examples/` (`breadcrumb.test.tsx`, `use-hook.test.ts`, `util.test.ts`)
+
+## 시작 전 체크리스트
+
+- [ ] 대상 소스 파일을 읽었는가?
+- [ ] 대상이 컴포넌트 / hook / 그 외 일반 JS·TS 중 어디인지 분류했는가?
+- [ ] 적합한 `references/*.md`를 1개 골라 읽었는가?
+- [ ] 시각 회귀로 다뤄야 할 prop을 유닛 테스트에 넣고 있지 않은가?

--- a/.claude/skills/vapor-unit-test/SKILL.md
+++ b/.claude/skills/vapor-unit-test/SKILL.md
@@ -19,11 +19,11 @@ vapor-ui 모노레포의 모든 유닛 테스트를 작성·리뷰합니다.
 
 작성 대상에 맞춰 references/ 안의 가이드 한 개를 골라 읽으세요. **전부 한꺼번에 로드하지 마세요.**
 
-| 대상 | 가이드 |
-| --- | --- |
-| React 컴포넌트 | `references/component-tests.md` |
-| React 커스텀 hook (`use*`) | `references/hook-tests.md` |
-| 그 외 일반 JS/TS 파일 (순수 함수, 변환기, 생성기, 린트 규칙 등) | `references/general-tests.md` |
+| 대상                                                            | 가이드                          |
+| --------------------------------------------------------------- | ------------------------------- |
+| React 컴포넌트                                                  | `references/component-tests.md` |
+| React 커스텀 hook (`use*`)                                      | `references/hook-tests.md`      |
+| 그 외 일반 JS/TS 파일 (순수 함수, 변환기, 생성기, 린트 규칙 등) | `references/general-tests.md`   |
 
 작성 전에 **반드시 대상 소스 파일을 먼저 읽으세요.** 무엇을 테스트할지, 무엇이 위임(delegation)이라 테스트가 불필요한지 판단하기 위해서입니다.
 
@@ -58,6 +58,7 @@ vapor-ui 모노레포의 모든 유닛 테스트를 작성·리뷰합니다.
 테스트가 외부 fixture(`.input.tsx`/`.output.tsx`, JSON 모킹 데이터, 큰 입력 스냅샷 등)를 사용하면 **테스트 파일과 같은 위치의 `__testfixtures__/` 하위 폴더**에 둡니다 (`__testfixtures__`는 jscodeshift 관례명, 다른 도메인도 동일 이름 사용).
 
 이유:
+
 - 소스 폴더에 fixture가 섞이면 본체 파일 식별이 어려워짐
 - fixture는 의도적으로 부분/구버전 코드인 경우가 많아 빌드·타입체크 글롭이 fixture를 잡으면 오탐 발생 → `__testfixtures__/`는 vitest/tsconfig 글롭에서 한 번에 제외하기 쉬움
 
@@ -77,7 +78,7 @@ vapor-ui 모노레포의 모든 유닛 테스트를 작성·리뷰합니다.
 Vitest는 `globals: true` 설정으로 동작합니다. 다음 식별자는 **import 하지 마세요** — 전역으로 제공됩니다.
 
 ```ts
-describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi
+(describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi);
 ```
 
 `Mock` 등 타입만은 `import type { Mock } from 'vitest'`로 가져옵니다.

--- a/.claude/skills/vapor-unit-test/references/component-tests.md
+++ b/.claude/skills/vapor-unit-test/references/component-tests.md
@@ -13,11 +13,11 @@ describe('Button', () => {
 });
 ```
 
-`cleanup`은 RTL이 자동으로 호출하므로 **기본적으로 추가하지 않습니다.** 한 `it()` 내부에서 여러 번 `render`를 호출하는 등 특수한 경우에만 명시적으로 `afterEach(cleanup)` 또는 `cleanup()`을 직접 호출하세요.
+`cleanup`은 RTL이 자동으로 호출하므로 명시적으로 추가하지 않습니다.
 
 ## describe 그룹
 
-테스트가 **2개 이상의 카테고리**로 나뉠 때만 nested describe로 묶습니다. 카테고리가 1개거나 테스트가 몇 개 안 되면 nested 없이 최상위 `describe`에 평탄하게 둡니다 — 불필요한 중첩은 가독성을 해칩니다.
+테스트가 **2개 이상의 카테고리**로 나뉠 때만 nested describe로 묶습니다. 카테고리가 1개거나 테스트 케이스가 적어 카테고리를 분류할 수 없는 경우 nested 없이 최상위 `describe`에 평탄하게 둡니다 — 불필요한 중첩은 가독성을 해칩니다.
 
 | 그룹 이름                          | 사용 시점                      |
 | ---------------------------------- | ------------------------------ |
@@ -27,23 +27,63 @@ describe('Button', () => {
 | `'keyboard navigation'`            | Tab, 화살표, Enter/Space 동작  |
 | `'prop: <propName>'`               | 특정 prop 동작                 |
 
-## 렌더 결과는 항상 `rendered`
+## 렌더 결과는 항상 `rendered` (테스트별로 직접 렌더)
+
+각 `it()` 안에서 직접 `render`를 호출하고 반환값을 `rendered`에 담습니다. 동일한 테스트베드를 여러 케이스가 쓰더라도 `beforeEach`로 공유하지 말고 각 테스트가 자기 렌더를 소유합니다.
 
 ```tsx
-const rendered = render(<ButtonTest />);
-```
+describe('Checkbox', () => {
+    it('is unchecked by default', () => {
+        const rendered = render(<CheckboxTest />);
+        const checkbox = rendered.getByRole('checkbox');
 
-이유: `render` 호출을 어떤 변수가 받았는지를 변수명으로 명시적으로 지목합니다. `screen`(전역) 대비 한 파일에 여러 `render`가 공존할 때 어느 렌더 트리에 대한 쿼리인지 추적하기 쉽고, "이 단언은 방금 렌더한 트리에 대한 것"이라는 의도가 코드에 그대로 드러납니다.
+        expect(checkbox).not.toBeChecked();
+    });
 
-`beforeEach`로 공유할 때:
+    it('toggles when clicked', async () => {
+        // 동일한 테스트베드라도 케이스마다 새로 렌더
+        const rendered = render(<CheckboxTest />);
+        const checkbox = rendered.getByRole('checkbox');
 
-```tsx
-let rendered: RenderResult;
+        await userEvent.click(checkbox);
 
-beforeEach(() => {
-    rendered = render(<CheckboxTest />);
+        expect(checkbox).toBeChecked();
+    });
 });
 ```
+
+이유:
+
+- **격리** — `beforeEach` 공유 렌더는 어떤 케이스만 다른 prop으로 렌더하고 싶어질 때, 이미 마운트된 트리를 지우려고 케이스 안에서 `cleanup()`을 부르는 지역적 회피를 강제합니다. 각 테스트가 자기 렌더를 소유하면 이 결합이 사라집니다.
+- **가독성** — `render`와 해당 단언이 같은 스코프에 있어 케이스 하나만 읽어도 전체 흐름을 파악할 수 있습니다.
+- **RTL 자동 cleanup** — 테스트가 끝나면 RTL이 마운트한 노드를 `document.body`에서 제거하므로 다음 테스트의 `render`는 항상 깨끗한 body 위에서 시작합니다.
+
+`rendered`라는 이름은 `screen`(전역) 대비 어느 렌더 트리에 대한 쿼리인지 코드에 그대로 드러내기 위함입니다 — 한 파일에 여러 `render`가 공존해도 추적이 쉽고, "이 단언은 방금 렌더한 트리에 대한 것"이라는 의도가 명확해집니다.
+
+### 렌더 결과를 참조하지 않는 경우
+
+트리를 마운트만 하고 쿼리는 `userEvent`, mock, 전역 side effect로만 검증하는 경우 — `rendered` 변수를 만들지 말고 `render()`만 호출합니다.
+
+```tsx
+it('should call onClick when Enter is pressed on focused item', async () => {
+    const onClick = vi.fn();
+
+    render(
+        <Breadcrumb.Root>
+            <Breadcrumb.Item href="away" onClick={onClick}>
+                Away
+            </Breadcrumb.Item>
+        </Breadcrumb.Root>,
+    );
+
+    await userEvent.tab();
+    await userEvent.keyboard('{Enter}');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+});
+```
+
+사용하지 않는 `rendered`는 "이 렌더에서 뭔가 조회할 것"이라는 잘못된 신호를 줍니다. 참조가 없으면 변수도 없어야 의도가 맞습니다.
 
 ## 요소 쿼리
 

--- a/.claude/skills/vapor-unit-test/references/component-tests.md
+++ b/.claude/skills/vapor-unit-test/references/component-tests.md
@@ -1,0 +1,222 @@
+# 컴포넌트 유닛 테스트 가이드
+
+React 컴포넌트를 **Vitest + React Testing Library**로 테스트합니다.
+파일 위치·import·`it()` 네이밍·mock·커버리지 같은 공통 규칙은 `SKILL.md` 참조. 이 문서는 컴포넌트 전용 컨벤션만 다룹니다.
+
+## 최상위 describe
+
+컴포넌트 이름을 문자열로 사용합니다.
+
+```tsx
+describe('Button', () => {
+    // ...
+});
+```
+
+`cleanup`은 RTL이 자동으로 호출하므로 **기본적으로 추가하지 않습니다.** 한 `it()` 내부에서 여러 번 `render`를 호출하는 등 특수한 경우에만 명시적으로 `afterEach(cleanup)` 또는 `cleanup()`을 직접 호출하세요.
+
+## describe 그룹
+
+테스트가 **2개 이상의 카테고리**로 나뉠 때만 nested describe로 묶습니다. 카테고리가 1개거나 테스트가 몇 개 안 되면 nested 없이 최상위 `describe`에 평탄하게 둡니다 — 불필요한 중첩은 가독성을 해칩니다.
+
+| 그룹 이름 | 사용 시점 |
+| --- | --- |
+| `'given a default <Component>'` | 기본 uncontrolled 상태 |
+| `'given a controlled <Component>'` | controlled value/onChange 상태 |
+| `'ARIA attributes'` | `aria-*` 속성 검증 전용 |
+| `'keyboard navigation'` | Tab, 화살표, Enter/Space 동작 |
+| `'prop: <propName>'` | 특정 prop 동작 |
+
+## 렌더 결과는 항상 `rendered`
+
+```tsx
+const rendered = render(<ButtonTest />);
+```
+
+이유: `render` 호출을 어떤 변수가 받았는지를 변수명으로 명시적으로 지목합니다. `screen`(전역) 대비 한 파일에 여러 `render`가 공존할 때 어느 렌더 트리에 대한 쿼리인지 추적하기 쉽고, "이 단언은 방금 렌더한 트리에 대한 것"이라는 의도가 코드에 그대로 드러납니다.
+
+`beforeEach`로 공유할 때:
+
+```tsx
+let rendered: RenderResult;
+
+beforeEach(() => {
+    rendered = render(<CheckboxTest />);
+});
+```
+
+## 요소 쿼리
+
+쿼리는 `rendered`에서 chain하고, **반드시 의미 있는 이름의 변수에 담은 뒤 assert** 합니다. `expect()` 안에 인라인하지 않습니다.
+
+```tsx
+const trigger = rendered.getByRole('button', { name: 'Open' });
+const popup = rendered.getByRole('dialog');
+expect(trigger).toBeInTheDocument();
+expect(popup).toBeInTheDocument();
+
+// bad — anonymous
+const el = rendered.getByRole('button');
+
+// bad — inlined query
+expect(rendered.getByRole('listbox')).toBeInTheDocument();
+```
+
+부재(absence) 검증 시에는 `queryBy*` 사용:
+
+```tsx
+const popup = rendered.queryByRole('listbox');
+expect(popup).not.toBeInTheDocument();
+```
+
+### 비동기 등장/사라짐
+
+Testing Library 공식 가이드 그대로 따릅니다.
+
+- **비동기 등장** → `findBy*` (Promise 반환, 기본 timeout까지 polling)
+- **비동기 사라짐** → `waitFor` + `queryBy*`
+
+```tsx
+// 등장
+const popup = await rendered.findByRole('dialog');
+expect(popup).toBeInTheDocument();
+
+// 사라짐
+await waitFor(() => {
+    expect(rendered.queryByRole('dialog')).not.toBeInTheDocument();
+});
+```
+
+`getBy*`를 `waitFor`로 감싸는 패턴은 피하세요 — `findBy*` 한 줄이면 됩니다.
+
+### ARIA role이 아니라 컴포넌트 이름으로 변수명 짓기
+
+개발자가 코드에서 보는 것은 컴포넌트 이름입니다. 변수명도 그에 맞추면 JSX와 테스트가 같은 어휘를 공유합니다.
+
+| 컴포넌트 | ARIA role | 변수명 |
+| --- | --- | --- |
+| `Select.Trigger` | `combobox` | `trigger` |
+| `Select.Popup` | `listbox` | `popup` |
+| `Select.Item` | `option` | `appleItem`, `bananaItem`, … |
+| `Dialog.Trigger` | `button` | `trigger` |
+| `Dialog.Popup` | `dialog` | `popup` |
+| `Menu.Item` | `menuitem` | `deleteItem`, `editItem`, … |
+
+여러 item 중에서는 콘텐츠 라벨을 접두사로 붙여 구분(`appleItem`, `item1` 금지).
+
+## 접근성 테스트 (필수)
+
+모든 컴포넌트 테스트 파일에 a11y 체크 1개는 반드시 포함합니다.
+
+`axe`는 **`vitest-axe`**에서 import (`jest-axe` 아님 — Vitest 환경).
+
+```tsx
+import { axe } from 'vitest-axe';
+
+it('should have no a11y violations', async () => {
+    const rendered = render(<ComponentTest />);
+    const result = await axe(rendered.container);
+
+    expect(result).toHaveNoViolations();
+});
+```
+
+`toHaveNoViolations` matcher는 프로젝트 vitest setup이 등록합니다(개별 import 불필요).
+
+## 사용자 인터랙션
+
+모든 액션은 `@testing-library/user-event`로. **기본은 직접 호출 (`userEvent.click(...)`).**
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+await userEvent.click(button);
+await userEvent.tab();
+await userEvent.keyboard('{Escape}');
+await userEvent.keyboard('{Enter}');
+await userEvent.type(input, 'hello');
+```
+
+`userEvent.setup()`은 **옵션을 넘겨야 할 때만** 사용. 옵션이 없으면 인스턴스를 만들지 않습니다.
+
+```tsx
+// 옵션이 필요한 경우 — fake timer, delay, pointerEventsCheck 비활성화 등
+const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+await user.click(button);
+```
+
+`userEvent`가 아니라 DOM 메서드를 직접 부를 때는 React가 상태를 flush할 시간을 주기 위해 `waitFor`로 감쌉니다.
+
+```tsx
+// good
+await waitFor(() => trigger.focus());
+
+// bad — focus()는 동기지만 다음 keyboard 호출이 렌더 사이클보다 먼저 발화할 수 있음
+trigger.focus();
+```
+
+## 상태 단언
+
+### 네이티브 HTML 상태
+
+브라우저가 네이티브로 반영하는 상태는 의미 있는 matcher를 씁니다.
+
+```tsx
+expect(checkbox).toBeChecked();
+expect(button).toBeDisabled();
+expect(input).toBeRequired();
+expect(input).toHaveFocus();
+expect(element).toBeInTheDocument();
+```
+
+### JS가 관리하는 상태 (div 기반, Base UI 컴포넌트)
+
+`<div>`나 비네이티브 인터랙티브 요소가 `aria-*` / `data-*`로 상태를 표현하면 `toHaveAttribute` 사용.
+
+```tsx
+// aria-*
+expect(element).toHaveAttribute('aria-disabled', 'true');
+expect(element).toHaveAttribute('aria-checked', 'mixed');
+expect(element).toHaveAttribute('aria-invalid', 'true');
+expect(element).toHaveAttribute('aria-current', 'page');
+
+// data-* (Base UI 패턴)
+expect(element).toHaveAttribute('data-disabled', '');
+expect(element).toHaveAttribute('data-checked', '');
+```
+
+원칙: 진짜 `<input>`, `<button>`, `<select>` → 의미 있는 matcher / 그 외 → `toHaveAttribute`.
+
+## 컴포넌트가 정의한 콜백만 테스트
+
+자체 API로 정의한 콜백만 다룹니다. 단순히 DOM으로 forward되는 네이티브 이벤트는 테스트하지 않습니다.
+
+- **테스트 대상** — 컴포넌트 로직이 들어간 콜백:
+  `onCheckedChange`, `onValueChange`, `onOpenChange`, `onSelect`, `onDismiss`
+- **건너뛰기** — 단순 forward되는 네이티브 이벤트:
+  `onFocus`, `onBlur`, 단순 wrapper의 `onClick`, `onKeyDown`, `onMouseEnter`
+
+이유: 네이티브 이벤트는 브라우저가 처리합니다. 테스트해 봤자 React의 이벤트 시스템이 동작하는지 확인할 뿐 컴포넌트 동작 검증이 아닙니다. 컴포넌트 콜백은 발화 시점, payload, `disabled`/`readOnly` 같은 조건 존중 여부를 검증할 가치가 있습니다.
+
+콜백 실행은 실제 사용자 인터랙션(`userEvent.click`, `userEvent.tab`, `userEvent.type`)을 통해 트리거하세요. 그래야 콜백 주변의 컴포넌트 로직까지 함께 검증됩니다.
+
+## 테스트용 wrapper 패턴
+
+파일 하단에 가벼운 wrapper를 정의해 JSX를 깔끔하게 유지합니다.
+
+```tsx
+const LABEL_TEXT = 'My Checkbox';
+
+const CheckboxTest = (props: Checkbox.Root.Props) => (
+    <>
+        <Checkbox.Root id="cb" aria-label={LABEL_TEXT} {...props} />
+        <label htmlFor="cb">{LABEL_TEXT}</label>
+    </>
+);
+```
+
+`TRIGGER_TEXT`, `CLOSE_TEXT`, `LABEL_TEXT` 같은 상수는 모듈 최상단(파일 위쪽)에 둡니다.
+
+## 풀 예시
+
+`references/examples/breadcrumb.test.tsx` 참고.

--- a/.claude/skills/vapor-unit-test/references/component-tests.md
+++ b/.claude/skills/vapor-unit-test/references/component-tests.md
@@ -19,13 +19,13 @@ describe('Button', () => {
 
 테스트가 **2개 이상의 카테고리**로 나뉠 때만 nested describe로 묶습니다. 카테고리가 1개거나 테스트가 몇 개 안 되면 nested 없이 최상위 `describe`에 평탄하게 둡니다 — 불필요한 중첩은 가독성을 해칩니다.
 
-| 그룹 이름 | 사용 시점 |
-| --- | --- |
-| `'given a default <Component>'` | 기본 uncontrolled 상태 |
+| 그룹 이름                          | 사용 시점                      |
+| ---------------------------------- | ------------------------------ |
+| `'given a default <Component>'`    | 기본 uncontrolled 상태         |
 | `'given a controlled <Component>'` | controlled value/onChange 상태 |
-| `'ARIA attributes'` | `aria-*` 속성 검증 전용 |
-| `'keyboard navigation'` | Tab, 화살표, Enter/Space 동작 |
-| `'prop: <propName>'` | 특정 prop 동작 |
+| `'ARIA attributes'`                | `aria-*` 속성 검증 전용        |
+| `'keyboard navigation'`            | Tab, 화살표, Enter/Space 동작  |
+| `'prop: <propName>'`               | 특정 prop 동작                 |
 
 ## 렌더 결과는 항상 `rendered`
 
@@ -93,14 +93,14 @@ await waitFor(() => {
 
 개발자가 코드에서 보는 것은 컴포넌트 이름입니다. 변수명도 그에 맞추면 JSX와 테스트가 같은 어휘를 공유합니다.
 
-| 컴포넌트 | ARIA role | 변수명 |
-| --- | --- | --- |
-| `Select.Trigger` | `combobox` | `trigger` |
-| `Select.Popup` | `listbox` | `popup` |
-| `Select.Item` | `option` | `appleItem`, `bananaItem`, … |
-| `Dialog.Trigger` | `button` | `trigger` |
-| `Dialog.Popup` | `dialog` | `popup` |
-| `Menu.Item` | `menuitem` | `deleteItem`, `editItem`, … |
+| 컴포넌트         | ARIA role  | 변수명                       |
+| ---------------- | ---------- | ---------------------------- |
+| `Select.Trigger` | `combobox` | `trigger`                    |
+| `Select.Popup`   | `listbox`  | `popup`                      |
+| `Select.Item`    | `option`   | `appleItem`, `bananaItem`, … |
+| `Dialog.Trigger` | `button`   | `trigger`                    |
+| `Dialog.Popup`   | `dialog`   | `popup`                      |
+| `Menu.Item`      | `menuitem` | `deleteItem`, `editItem`, …  |
 
 여러 item 중에서는 콘텐츠 라벨을 접두사로 붙여 구분(`appleItem`, `item1` 금지).
 

--- a/.claude/skills/vapor-unit-test/references/examples/breadcrumb.test.tsx
+++ b/.claude/skills/vapor-unit-test/references/examples/breadcrumb.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'vitest-axe';
+
+import { Breadcrumb } from '.';
+
+describe('Breadcrumb', () => {
+    it('should have no a11y violations', async () => {
+        const rendered = render(<BreadcrumbTest />);
+        const result = await axe(rendered.container);
+
+        expect(result).toHaveNoViolations();
+    });
+
+    describe('ARIA attributes', () => {
+        it('should have `aria-current="page"` when the item is current', () => {
+            const rendered = render(<BreadcrumbTest />);
+            const currentItem = rendered.getByRole('link', { name: 'Products' });
+
+            expect(currentItem).toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    describe('keyboard navigation', () => {
+        it('should support keyboard navigation via Tab and Enter', async () => {
+            const onClick = vi.fn();
+            render(
+                <Breadcrumb.Root>
+                    <Breadcrumb.Item href="home">Home</Breadcrumb.Item>
+                    <Breadcrumb.Item href="away" onClick={onClick}>
+                        Away
+                    </Breadcrumb.Item>
+                </Breadcrumb.Root>,
+            );
+
+            await userEvent.tab();
+            await userEvent.tab();
+            await userEvent.keyboard('{Enter}');
+
+            expect(onClick).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('prop: current', () => {
+        it('sets aria-current="page" on the active item', () => {
+            const rendered = render(<BreadcrumbTest />);
+            const currentItem = rendered.getByRole('link', { name: 'Products' });
+
+            expect(currentItem).toHaveAttribute('aria-current', 'page');
+        });
+    });
+});
+
+const BreadcrumbTest = (props: Breadcrumb.Root.Props) => (
+    <Breadcrumb.Root {...props}>
+        <Breadcrumb.Item href="home">Home</Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item href="products" current>
+            Products
+        </Breadcrumb.Item>
+    </Breadcrumb.Root>
+);

--- a/.claude/skills/vapor-unit-test/references/examples/use-hook.test.ts
+++ b/.claude/skills/vapor-unit-test/references/examples/use-hook.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useInterval } from './useInterval';
+
+describe('useInterval', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('fires the callback every interval', () => {
+        const callback = vi.fn();
+        renderHook(() => useInterval(callback, 1000));
+
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        expect(callback).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not fire the callback when delay is null', () => {
+        const callback = vi.fn();
+        renderHook(() => useInterval(callback, null));
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('updates the interval when delay changes', () => {
+        const callback = vi.fn();
+        const view = renderHook(({ delay }) => useInterval(callback, delay), {
+            initialProps: { delay: 1000 },
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+        expect(callback).toHaveBeenCalledTimes(2);
+
+        view.rerender({ delay: 500 });
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+
+        expect(callback).toHaveBeenCalledTimes(4);
+    });
+
+    it('clears the interval on unmount', () => {
+        const callback = vi.fn();
+        const view = renderHook(() => useInterval(callback, 1000));
+
+        view.unmount();
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('always invokes the latest callback', () => {
+        const first = vi.fn();
+        const second = vi.fn();
+
+        const view = renderHook(({ cb }) => useInterval(cb, 1000), {
+            initialProps: { cb: first },
+        });
+
+        view.rerender({ cb: second });
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+});

--- a/.claude/skills/vapor-unit-test/references/examples/util.test.ts
+++ b/.claude/skills/vapor-unit-test/references/examples/util.test.ts
@@ -43,9 +43,7 @@ describe('stateful-props', () => {
     // 엣지 케이스: 잘못된 입력에 대한 throw
     describe('resolveClassName — invalid input', () => {
         it('throws when the resolver is neither a string nor a function', () => {
-            expect(() =>
-                resolveClassName(42 as unknown as string, { active: true }),
-            ).toThrow();
+            expect(() => resolveClassName(42 as unknown as string, { active: true })).toThrow();
         });
     });
 

--- a/.claude/skills/vapor-unit-test/references/examples/util.test.ts
+++ b/.claude/skills/vapor-unit-test/references/examples/util.test.ts
@@ -1,0 +1,77 @@
+import { mergeStatefulProps, resolveClassName, resolveStyle } from './stateful-props';
+
+describe('stateful-props', () => {
+    describe('mergeStatefulProps', () => {
+        it('merges static className and style values', () => {
+            const merged = mergeStatefulProps(
+                { className: 'base', style: { opacity: 0.4 } },
+                { className: 'external', style: { pointerEvents: 'none' as const } },
+            );
+
+            expect(merged.className).toBe('base external');
+            expect(merged.style).toEqual({ opacity: 0.4, pointerEvents: 'none' });
+        });
+
+        it('preserves function className when external className is a resolver', () => {
+            const merged = mergeStatefulProps<{ active: boolean }>(
+                { className: 'base' },
+                { className: (state) => (state.active ? 'active' : undefined) },
+            );
+
+            expect(typeof merged.className).toBe('function');
+
+            if (typeof merged.className === 'function') {
+                expect(merged.className({ active: true })).toBe('base active');
+                expect(merged.className({ active: false })).toBe('base');
+            }
+        });
+
+        it('returns the external value when the internal value is undefined', () => {
+            const merged = mergeStatefulProps({}, { className: 'external' });
+
+            expect(merged.className).toBe('external');
+        });
+
+        // 엣지 케이스: 빈 입력
+        it('returns an empty object when both inputs are empty', () => {
+            const merged = mergeStatefulProps({}, {});
+
+            expect(merged).toEqual({});
+        });
+    });
+
+    // 엣지 케이스: 잘못된 입력에 대한 throw
+    describe('resolveClassName — invalid input', () => {
+        it('throws when the resolver is neither a string nor a function', () => {
+            expect(() =>
+                resolveClassName(42 as unknown as string, { active: true }),
+            ).toThrow();
+        });
+    });
+
+    describe('resolveClassName', () => {
+        it('invokes the resolver with the given state', () => {
+            const resolved = resolveClassName<{ active: boolean }>(
+                (state) => (state.active ? 'active' : ''),
+                { active: true },
+            );
+
+            expect(resolved).toBe('active');
+        });
+
+        it('returns string values as-is', () => {
+            expect(resolveClassName('static', { active: true })).toBe('static');
+        });
+    });
+
+    describe('resolveStyle', () => {
+        it('resolves a generic stateful style object', () => {
+            const style = resolveStyle<{ active: boolean }>(
+                (state) => ({ opacity: state.active ? 1 : 0.4 }),
+                { active: false },
+            );
+
+            expect(style).toEqual({ opacity: 0.4 });
+        });
+    });
+});

--- a/.claude/skills/vapor-unit-test/references/general-tests.md
+++ b/.claude/skills/vapor-unit-test/references/general-tests.md
@@ -1,0 +1,106 @@
+# 일반 JS/TS 코드 유닛 테스트 가이드
+
+React 컴포넌트와 hook이 아닌 모든 JS/TS 파일의 테스트를 다룹니다. 순수 함수, 변환기(transform), 생성기(generator), 린트 규칙 등 카테고리에 상관없이 동일한 패턴이 적용됩니다.
+
+파일 위치·외부 fixture·import·`it()` 네이밍·mock·커버리지 같은 공통 규칙은 `SKILL.md` 참조. 이 문서는 일반 JS/TS 코드 전용 컨벤션만 다룹니다.
+
+## 기본 패턴: input → output 검증
+
+대상이 순수 함수면 setup도 mock도 거의 필요 없습니다. 입력을 주고 반환값을 검증하는 것이 본질.
+
+```ts
+import { mergeStatefulProps } from './stateful-props';
+
+describe('mergeStatefulProps', () => {
+    it('merges static className and style values', () => {
+        const merged = mergeStatefulProps(
+            { className: 'base', style: { opacity: 0.4 } },
+            { className: 'external', style: { pointerEvents: 'none' as const } },
+        );
+
+        expect(merged.className).toBe('base external');
+        expect(merged.style).toEqual({ opacity: 0.4, pointerEvents: 'none' });
+    });
+});
+```
+
+## describe 그룹
+
+- 검증 대상이 함수 1개면 그 함수 이름을 최상위 `describe`로 사용
+- 한 파일이 여러 함수를 export하면 함수별로 `describe`를 만들고, 파일 이름을 최상위 `describe`로 감쌈
+- 단일 함수의 동작이 여러 카테고리로 나뉘면(예: 정상 경로 / 에러 / 옵션별 분기) 동작별 nested `describe`
+
+```ts
+describe('color-generator', () => {
+    describe('generatePrimitiveColorPalette', () => {
+        it('returns default palette when no options provided', ...);
+        it('applies brand color when given', ...);
+    });
+
+    describe('getSemanticDependentTokens', () => {
+        it('maps standard brand color', ...);
+    });
+});
+```
+
+## 엣지 케이스를 반드시 다룬다
+
+순수 함수가 빠지기 쉬운 함정:
+
+- 빈 입력 (`''`, `[]`, `{}`, `null`, `undefined`)
+- 경계값 (0, 음수, `Number.MAX_SAFE_INTEGER`)
+- 잘못된 입력 형식 → throw 하는지 fallback 반환하는지
+- 유니코드, 멀티바이트, 이모지
+- 부동소수점 정밀도
+
+```ts
+it('throws on invalid hex color', () => {
+    expect(() => generatePrimitiveColorPalette({
+        brandColor: { name: 'invalid', hexcode: 'invalid-hex' },
+    })).toThrow('Invalid brand color hex');
+});
+```
+
+## 언제 snapshot을 쓸까
+
+`toMatchSnapshot()`은 **큰 결정론적 출력**(생성된 토큰 트리, AST 변환 결과, 생성된 CSS) 검증에만 사용합니다.
+
+**쓰기 좋은 경우**:
+
+- 옵션별로 큰 객체를 생성하는 함수의 회귀 방지
+- 변환 전/후를 fixture 파일로 비교할 때 (보통은 도메인 헬퍼가 처리)
+
+**쓰지 말아야 할 경우**:
+
+- 1~2 줄 출력 — 그냥 `expect(...).toBe(...)`로 명시
+- 동작별 의도가 다른 케이스 — snapshot은 "변하지 않음"만 보장하지 "왜 그래야 하는지"를 표현하지 못함
+- 부동소수점·시간·랜덤이 섞인 출력
+
+snapshot 갱신 시 의도된 변경인지 반드시 확인 후 `pnpm test -u`.
+
+## 도메인 헬퍼·테스트 유틸이 있다면 그것을 우선 사용
+
+대상 도메인이 자체 테스트 헬퍼를 제공하면 직접 fixture를 읽거나 변환을 호출하지 말고 그 헬퍼를 통해 작성. 헬퍼는 fixture 로드, 정규화, diff 표시 같은 보일러플레이트를 처리합니다.
+
+예시 — codemod transform 테스트 (`__testfixtures__/` 안의 input/output 쌍을 자동 비교):
+
+```ts
+import { join } from 'node:path';
+
+import { runTestTransform } from '~/utils/test';
+
+import transform from './index';
+
+runTestTransform({
+    transform,
+    fixturesDir: join(__dirname, '__testfixtures__'),
+});
+```
+
+예시 — ESLint 규칙 테스트는 `RuleTester`의 `valid`/`invalid` 배열에 코드 스니펫과 기대 메시지를 적습니다. 새 규칙을 만들 때는 기존 규칙의 구조를 그대로 따르세요.
+
+새로운 도메인 헬퍼를 만들고 있다면, 헬퍼 호출 1줄로 끝낼 수 있는 형태(테스트 의도가 한눈에 보이도록)를 우선 검토.
+
+## 풀 예시
+
+`references/examples/util.test.ts` 참고.

--- a/.claude/skills/vapor-unit-test/references/general-tests.md
+++ b/.claude/skills/vapor-unit-test/references/general-tests.md
@@ -55,9 +55,11 @@ describe('color-generator', () => {
 
 ```ts
 it('throws on invalid hex color', () => {
-    expect(() => generatePrimitiveColorPalette({
-        brandColor: { name: 'invalid', hexcode: 'invalid-hex' },
-    })).toThrow('Invalid brand color hex');
+    expect(() =>
+        generatePrimitiveColorPalette({
+            brandColor: { name: 'invalid', hexcode: 'invalid-hex' },
+        }),
+    ).toThrow('Invalid brand color hex');
 });
 ```
 

--- a/.claude/skills/vapor-unit-test/references/hook-tests.md
+++ b/.claude/skills/vapor-unit-test/references/hook-tests.md
@@ -18,7 +18,7 @@ describe('useInterval', () => {
 `@testing-library/react`의 `renderHook`을 사용합니다. 결과 변수명은 `view`(`rendered`는 컴포넌트 테스트 전용).
 
 ```ts
-import { renderHook, act } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 const view = renderHook(() => useCounter(0));
 

--- a/.claude/skills/vapor-unit-test/references/hook-tests.md
+++ b/.claude/skills/vapor-unit-test/references/hook-tests.md
@@ -1,0 +1,134 @@
+# 커스텀 hook 유닛 테스트 가이드
+
+React 커스텀 hook을 테스트합니다.
+파일 위치·import·`it()` 네이밍·mock·커버리지 같은 공통 규칙은 `SKILL.md` 참조. 이 문서는 hook 전용 컨벤션만 다룹니다.
+
+## 최상위 describe
+
+hook 이름을 문자열로 사용합니다.
+
+```ts
+describe('useInterval', () => {
+    // ...
+});
+```
+
+## `renderHook` 사용
+
+`@testing-library/react`의 `renderHook`을 사용합니다. 결과 변수명은 `view`(`rendered`는 컴포넌트 테스트 전용).
+
+```ts
+import { renderHook, act } from '@testing-library/react';
+
+const view = renderHook(() => useCounter(0));
+
+expect(view.result.current.count).toBe(0);
+```
+
+### prop 변경 (rerender)
+
+`initialProps`와 `rerender`로 prop 변화를 검증합니다.
+
+```ts
+const view = renderHook(({ delay }) => useDebounce('value', delay), {
+    initialProps: { delay: 500 },
+});
+
+view.rerender({ delay: 1000 });
+```
+
+## 상태 변경은 반드시 `act`로 감싸기
+
+hook이 노출한 setter나 핸들러는 `act` 안에서 호출합니다. 그래야 React가 상태 업데이트를 flush합니다.
+
+```ts
+import { act } from '@testing-library/react';
+
+it('increments count', () => {
+    const view = renderHook(() => useCounter(0));
+
+    act(() => {
+        view.result.current.increment();
+    });
+
+    expect(view.result.current.count).toBe(1);
+});
+```
+
+## 타이머·비동기
+
+`setTimeout`/`setInterval`을 쓰는 hook은 `vi.useFakeTimers()`로 가짜 타이머를 활성화합니다.
+
+```ts
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+it('fires callback every interval', () => {
+    const callback = vi.fn();
+    renderHook(() => useInterval(callback, 1000));
+
+    act(() => {
+        vi.advanceTimersByTime(3000);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(3);
+});
+```
+
+`Promise` 기반 비동기:
+
+```ts
+await act(async () => {
+    await view.result.current.fetchData();
+});
+
+expect(view.result.current.data).toEqual(...);
+```
+
+## 언마운트 정리 검증
+
+cleanup 로직(이벤트 리스너 제거, 타이머 해제 등)이 있는 hook은 `view.unmount()` 후 사이드이펙트가 더 이상 발생하지 않는지 확인합니다.
+
+```ts
+it('clears interval on unmount', () => {
+    const callback = vi.fn();
+    const view = renderHook(() => useInterval(callback, 1000));
+
+    view.unmount();
+    act(() => {
+        vi.advanceTimersByTime(5000);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+});
+```
+
+## 무엇을 테스트할 가치가 있는가
+
+- **자체 로직** — 상태 전이, 디바운스/스로틀, 계산된 반환값, cleanup 동작
+- **prop 의존성** — `dependencies` 배열 변화 시 재실행 여부
+- **에러 처리** — invalid 입력 시 throw 하는지, fallback 반환하는지
+
+**테스트하지 않아도 되는 것** — React 자체 동작(useState가 렌더를 트리거하는지 등).
+
+## Context를 요구하는 hook
+
+Provider로 감싸는 wrapper 옵션을 사용합니다.
+
+```ts
+const wrapper = ({ children }) => (
+    <ThemeProvider value="dark">{children}</ThemeProvider>
+);
+
+const view = renderHook(() => useTheme(), { wrapper });
+expect(view.result.current).toBe('dark');
+```
+
+## 풀 예시
+
+`references/examples/use-hook.test.ts` 참고.


### PR DESCRIPTION
## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new end-to-end unit testing guidelines for the monorepo using Vitest, React Testing Library, and related conventions (including coverage targets and test structure rules).
  * Added reference guides for React component tests, React hook tests, and general JS/TS testing.
  * Added example test suites for a Breadcrumb component (accessibility + keyboard behavior), a `useInterval` hook (fake timers + cleanup), and `stateful-props` utilities (merging/resolution behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

 ## Summary

Adds `vapor-unit-test` skill — convention guide for writing Vitest + React Testing Library
  unit tests across the vapor-ui monorepo. Triggered by phrases like "테스트 추가해줘", "write
  unit tests", "커버리지 보강", "test 좀 짜줘" — no explicit skill invocation required.

  ## Structure

  Progressive disclosure: skill body stays short, dispatches to a single reference per target.

```
  vapor-unit-test/
  ├── SKILL.md                          # routing + rules common to all targets
  └── references/
      ├── component-tests.md            # React components
      ├── hook-tests.md                 # custom hooks
      ├── general-tests.md              # pure JS/TS (functions, transforms, lint rules…)
      └── examples/
          ├── breadcrumb.test.tsx
          ├── use-hook.test.ts
          └── util.test.ts
```

  `SKILL.md` carries the routing table + rules that apply regardless of target (file
  placement, fixture layout, imports, naming, mocks, coverage). Each reference is loaded only
  when its target matches — keeps Claude's context lean.

  ## Decisions

  - **Three targets, three references** — component / hook / general JS-TS. Each has
  materially different assertion vocabulary (RTL queries vs `renderHook`/`act` vs
  input→output), and bundling them into one doc would force Claude to read irrelevant guidance
  on every invocation.
  - **Examples as separate files, not inline** — full runnable test files survive scrolling
  and let Claude pattern-match on real shapes.
  - **Co-location by default, `__tests__/` for cross-file flows** — keeps single-file targets
  discoverable; isolates multi-file integration scenarios where co-location would clutter the
  source folder.
  - **Fixtures live under `__testfixtures__/`** — single glob name (jscodeshift convention)
  used across all domains so Vitest/tsconfig can exclude them in one place; prevents
  partial-source fixtures from breaking build/typecheck.
  - **Coverage gate: 80% across four indicators** — single explicit threshold, with a
  delegation rule (one-line forward to external lib = skip) so the guide doesn't push toward
  testing third-party code.
  - **TDD optional** — primary use case is writing tests against existing code; forcing
  red→green→refactor would conflict with how the skill is actually invoked.
  - **Visual props excluded** — `size`/`variant`/`color`/`shape` belong to visual regression;
  declaring this up front prevents redundant unit tests.


## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
