### PR TITLE
chore: gitignore reader-based local Claude docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ storybook-static
 /.source/
 
 # Claude local docs (reader-based: drafts & scratch, not team assets)
+CLAUDE.local.md
 handoff.md
 docs/research/
 docs/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,10 @@ storybook-static
 # docs
 /.source/
 
+# Claude local docs (reader-based: drafts & scratch, not team assets)
+handoff.md
+docs/research/
+docs/plans/
+
 # Worktrees
 .worktrees


### PR DESCRIPTION
## Related Issues

- VAPOR-146

## Description of Changes

Added the following rules to `.gitignore`:

- `CLAUDE.local.md`
- `handoff.md`
- `docs/research/`
- `docs/plans/`

**Criterion: split by reader, not by file type.** The single deciding question is whether an external contributor would find the file valuable and free of security concerns.

| File                                               | Handling  | Rationale                                                         |
| -------------------------------------------------- | --------- | ----------------------------------------------------------------- |
| `CLAUDE.md` (shared guide)                         | Commit    | Anthropic official recommendation (already tracked)               |
| `CLAUDE.local.md` (personal guide)                 | gitignore | Anthropic official recommendation                                 |
| `docs/adr/`, `docs/decisions/` (refined decisions) | Commit    | Team asset (institutional memory) — **not added to ignore rules** |
| `handoff.md`, `docs/research/*`, `docs/plans/*`    | gitignore | In-progress drafts / raw thinking                                 |

`docs/adr/` and `docs/decisions/` are intentionally left trackable as team assets; only `docs/research/` and `docs/plans/` are ignored. `CLAUDE.local.md` and `handoff.md` are personal/ephemeral, so they stay local.

## Checklist

- [x] The PR title follows the Conventional Commits convention.
- [ ] I have added tests for my changes. <!-- N/A: gitignore change -->
- [ ] I have updated the Storybook or relevant documentation. <!-- N/A -->
- [ ] I have added a changeset for this change. <!-- N/A: no user-facing impact -->
- [x] I have performed a self-code review.
- [x] I have followed the project's coding conventions and component patterns.
