### PR TITLE
feat: add `@vapor-ui/design-tokens` package for ssot

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -5,8 +5,7 @@
     "description": "Vapor design tokens (W3C DTCG 2025.10). Raw JSON only.",
     "type": "module",
     "exports": {
-        "./raws/*.json": "./raws/*.json",
-        "./package.json": "./package.json"
+        "./raws/*": "./raws/*.json"
     },
     "files": [
         "raws"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@vapor-ui/design-tokens",
+    "version": "0.0.1",
+    "private": true,
+    "description": "Vapor design tokens (W3C DTCG 2025.10). Raw JSON only.",
+    "type": "module",
+    "exports": {
+        "./raws/*.json": "./raws/*.json",
+        "./package.json": "./package.json"
+    },
+    "files": [
+        "raws"
+    ]
+}

--- a/packages/design-tokens/raws/border-radius.json
+++ b/packages/design-tokens/raws/border-radius.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "size": {
+        "borderRadius": {
+            "$type": "dimension",
+            "$description": "Scale for border radius properties such as border-radius. The number is a scale index, not a px value.",
+            "000": { "$value": { "value": 0, "unit": "px" } },
+            "050": { "$value": { "value": 2, "unit": "px" } },
+            "100": { "$value": { "value": 4, "unit": "px" } },
+            "200": { "$value": { "value": 6, "unit": "px" } },
+            "300": { "$value": { "value": 8, "unit": "px" } },
+            "400": { "$value": { "value": 12, "unit": "px" } },
+            "500": { "$value": { "value": 16, "unit": "px" } },
+            "600": { "$value": { "value": 20, "unit": "px" } },
+            "700": { "$value": { "value": 24, "unit": "px" } },
+            "800": { "$value": { "value": 32, "unit": "px" } },
+            "900": { "$value": { "value": 40, "unit": "px" } }
+        }
+    }
+}

--- a/packages/design-tokens/raws/dimension.json
+++ b/packages/design-tokens/raws/dimension.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "size": {
+        "dimension": {
+            "$type": "dimension",
+            "$description": "Scale for dimension properties such as width and height. The number is a scale index, not a px value.",
+            "025": { "$value": { "value": 2, "unit": "px" } },
+            "050": { "$value": { "value": 4, "unit": "px" } },
+            "075": { "$value": { "value": 6, "unit": "px" } },
+            "100": { "$value": { "value": 8, "unit": "px" } },
+            "150": { "$value": { "value": 12, "unit": "px" } },
+            "175": { "$value": { "value": 14, "unit": "px" } },
+            "200": { "$value": { "value": 16, "unit": "px" } },
+            "225": { "$value": { "value": 18, "unit": "px" } },
+            "250": { "$value": { "value": 20, "unit": "px" } },
+            "300": { "$value": { "value": 24, "unit": "px" } },
+            "400": { "$value": { "value": 32, "unit": "px" } },
+            "500": { "$value": { "value": 40, "unit": "px" } },
+            "600": { "$value": { "value": 48, "unit": "px" } },
+            "700": { "$value": { "value": 56, "unit": "px" } },
+            "800": { "$value": { "value": 64, "unit": "px" } }
+        }
+    }
+}

--- a/packages/design-tokens/raws/primitive-color.dark.json
+++ b/packages/design-tokens/raws/primitive-color.dark.json
@@ -1,0 +1,733 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "colors": {
+        "white": {
+            "$description": "Absolute white. Used as a base reference, not for direct use in themes.",
+            "$type": "color",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [1, 0, 0]
+            }
+        },
+        "black": {
+            "$description": "Absolute black. Used as a base reference, not for direct use in themes.",
+            "$type": "color",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [0, 0, 0]
+            }
+        },
+        "canvas": {
+            "$type": "color",
+            "$description": "Background canvas scale. Currently defined at the primitive level but carries semantic intent.",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [0.26, 0, 0]
+            }
+        },
+        "red": {
+            "$type": "color",
+            "$description": "Red color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.12, 29.23]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.35, 0.14, 29.23]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.42, 0.17, 29.23]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.2, 23.9]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.56, 0.2, 22.87]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.2, 20.75]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.75, 0.15, 20.83]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.1, 20.3]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.05, 21.13]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 17.28]
+                }
+            }
+        },
+        "pink": {
+            "$type": "color",
+            "$description": "Pink color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.12, 15.38]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.35, 0.14, 10.99]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.42, 0.17, 5.6]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.19, 1.77]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.56, 0.19, 1.98]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.18, 1.89]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.75, 0.15, 1.6]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.82, 0.11, 1.53]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.06, 359.84]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.99, 0.01, 357.79]
+                }
+            }
+        },
+        "grape": {
+            "$type": "color",
+            "$description": "Grape color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3, 0.15, 313.06]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.18, 315.66]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.43, 0.21, 317.34]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.52, 0.23, 319.06]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.56, 0.23, 319.08]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.66, 0.22, 318.78]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.75, 0.17, 319.32]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.82, 0.12, 319.05]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.06, 318.76]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 320.55]
+                }
+            }
+        },
+        "violet": {
+            "$type": "color",
+            "$description": "Violet color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3, 0.17, 286.41]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.2, 289.93]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.42, 0.21, 290.35]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.21, 290.09]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.55, 0.21, 290.42]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.19, 293.08]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.74, 0.15, 299.51]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.11, 304.85]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.06, 305.68]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 305.41]
+                }
+            }
+        },
+        "blue": {
+            "$type": "color",
+            "$description": "Blue color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3, 0.18, 264.19]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.35, 0.18, 263.41]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.41, 0.19, 261.79]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5, 0.19, 259.74]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.54, 0.19, 259.91]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.63, 0.17, 254.87]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.72, 0.14, 248.03]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8, 0.11, 242.65]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.89, 0.06, 242.83]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 247.91]
+                }
+            }
+        },
+        "cyan": {
+            "$type": "color",
+            "$description": "Cyan color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.28, 0.06, 239.62]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.33, 0.07, 233.01]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4, 0.08, 226.97]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.48, 0.09, 222.64]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.53, 0.1, 219.25]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.62, 0.11, 216.18]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.71, 0.12, 212.56]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.79, 0.09, 210.78]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.89, 0.05, 213.07]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 207.14]
+                }
+            }
+        },
+        "green": {
+            "$type": "color",
+            "$description": "Green color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.27, 0.07, 153.71]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.32, 0.08, 156.91]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.39, 0.09, 159.88]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.48, 0.1, 164.06]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.52, 0.11, 166.28]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.61, 0.11, 167.85]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.71, 0.12, 167.76]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.79, 0.12, 167.52]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.89, 0.07, 167.7]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 171.81]
+                }
+            }
+        },
+        "lime": {
+            "$type": "color",
+            "$description": "Lime color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.27, 0.09, 142.5]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.32, 0.11, 142.5]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.39, 0.13, 141.58]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.48, 0.15, 138.2]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.52, 0.16, 136.62]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.62, 0.17, 134.11]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.71, 0.19, 131.87]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.79, 0.2, 130.07]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.89, 0.11, 129.52]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.02, 130.17]
+                }
+            }
+        },
+        "yellow": {
+            "$type": "color",
+            "$description": "Yellow color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.09, 38.65]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.34, 0.1, 45.91]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.41, 0.1, 53.32]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5, 0.11, 62.47]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.54, 0.12, 65.22]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.64, 0.14, 71.53]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.73, 0.15, 77.59]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.17, 82.65]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.11, 84.98]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.02, 82.79]
+                }
+            }
+        },
+        "orange": {
+            "$type": "color",
+            "$description": "Orange color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3, 0.12, 29.23]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.35, 0.14, 29.23]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.42, 0.17, 29.23]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.19, 33.09]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.55, 0.19, 36.36]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.19, 44.3]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.74, 0.15, 45.58]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.11, 45.3]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.06, 46.35]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.99, 0.01, 56.32]
+                }
+            }
+        },
+        "gray": {
+            "$type": "color",
+            "$description": "Neutral gray scale. Chroma is 0 across all steps.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.28, 0, 0]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.33, 0, 0]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4, 0, 0]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.49, 0, 0]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.53, 0, 0]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.63, 0, 0]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.73, 0, 0]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8, 0, 0]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.89, 0, 0]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.99, 0, 0]
+                }
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/primitive-color.light.json
+++ b/packages/design-tokens/raws/primitive-color.light.json
@@ -1,0 +1,733 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "colors": {
+        "white": {
+            "$type": "color",
+            "$description": "Absolute white. Used as a base reference, not for direct use in themes.",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [1, 0, 0]
+            }
+        },
+        "black": {
+            "$type": "color",
+            "$description": "Absolute black. Used as a base reference, not for direct use in themes.",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [0, 0, 0]
+            }
+        },
+        "canvas": {
+            "$type": "color",
+            "$description": "Background canvas scale. Currently defined at the primitive level but carries semantic intent.",
+            "$value": {
+                "colorSpace": "oklch",
+                "components": [1, 0, 0]
+            }
+        },
+        "red": {
+            "$type": "color",
+            "$description": "Red color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 24.32]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0.04, 19.72]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.84, 0.09, 19.96]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.74, 0.16, 20.63]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.69, 0.18, 20.46]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.59, 0.2, 22.21]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.2, 24.18]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.44, 0.18, 28.27]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.15, 29.23]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.12, 29.23]
+                }
+            }
+        },
+        "pink": {
+            "$type": "color",
+            "$description": "Pink color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 3.49]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.92, 0.05, 0.81]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.84, 0.09, 1.69]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.74, 0.15, 1.52]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.69, 0.18, 1.66]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.59, 0.19, 1.6]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.2, 1.61]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.44, 0.18, 4.31]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.15, 9.49]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.11, 15.78]
+                }
+            }
+        },
+        "grape": {
+            "$type": "color",
+            "$description": "Grape color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 318.7]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.92, 0.06, 319.46]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.84, 0.11, 319.12]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.74, 0.17, 318.84]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.69, 0.2, 319.05]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6, 0.22, 319.09]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.51, 0.23, 318.75]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.45, 0.22, 318.28]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.37, 0.18, 315.66]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.15, 312.06]
+                }
+            }
+        },
+        "violet": {
+            "$type": "color",
+            "$description": "Violet color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 304.14]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.92, 0.05, 305.47]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.84, 0.1, 305.18]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.73, 0.15, 298.86]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.69, 0.17, 295.47]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.59, 0.21, 290.06]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5, 0.21, 290.23]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.44, 0.21, 290.17]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.37, 0.21, 289.98]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.17, 286.26]
+                }
+            }
+        },
+        "blue": {
+            "$type": "color",
+            "$description": "Blue color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.97, 0.01, 240.95]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0.05, 241.64]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.82, 0.1, 242.82]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.71, 0.14, 247.99]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.67, 0.16, 252]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.57, 0.19, 259.7]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.49, 0.19, 259.76]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.43, 0.19, 261.22]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.18, 263.22]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.29, 0.18, 264.21]
+                }
+            }
+        },
+        "cyan": {
+            "$type": "color",
+            "$description": "Cyan color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.97, 0.01, 209.81]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0.04, 211.85]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.82, 0.08, 212.09]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.71, 0.12, 212.77]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.66, 0.11, 214.15]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.56, 0.1, 219.52]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.47, 0.09, 223.24]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.41, 0.08, 226.66]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.34, 0.07, 233.02]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.27, 0.06, 240.55]
+                }
+            }
+        },
+        "green": {
+            "$type": "color",
+            "$description": "Green color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.97, 0.02, 166.73]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.06, 167.05]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.11, 167.48]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7, 0.12, 167.2]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.12, 167.46]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.55, 0.11, 167.28]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.47, 0.1, 163.7]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.41, 0.09, 161.79]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.33, 0.08, 157.79]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.26, 0.07, 152.19]
+                }
+            }
+        },
+        "lime": {
+            "$type": "color",
+            "$description": "Lime color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.97, 0.03, 128.76]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9, 0.1, 130.28]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.81, 0.18, 129.92]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7, 0.19, 132.06]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.65, 0.18, 133.24]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.55, 0.16, 135.49]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.47, 0.15, 138.41]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.41, 0.13, 140.86]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.34, 0.11, 142.5]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.26, 0.09, 142.5]
+                }
+            }
+        },
+        "yellow": {
+            "$type": "color",
+            "$description": "Yellow color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.02, 84.59]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0.1, 85.28]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.83, 0.17, 84.5]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.72, 0.15, 77.5]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.67, 0.14, 74.08]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.58, 0.13, 67.82]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.49, 0.11, 61.8]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.43, 0.11, 54.86]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.35, 0.1, 46.87]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.28, 0.09, 37.13]
+                }
+            }
+        },
+        "orange": {
+            "$type": "color",
+            "$description": "Orange color scale.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0.01, 51.32]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0.05, 45.51]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.84, 0.09, 45.87]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.73, 0.15, 45.89]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.69, 0.18, 45.9]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.59, 0.19, 39.37]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5, 0.19, 32.51]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.44, 0.18, 29.23]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.36, 0.15, 29.23]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.28, 0.12, 29.23]
+                }
+            }
+        },
+        "gray": {
+            "$type": "color",
+            "$description": "Neutral gray scale. Chroma is 0 across all steps.",
+            "050": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.98, 0, 0]
+                }
+            },
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.91, 0, 0]
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.83, 0, 0]
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.72, 0, 0]
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.67, 0, 0]
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.57, 0, 0]
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.48, 0, 0]
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.42, 0, 0]
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.34, 0, 0]
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.27, 0, 0]
+                }
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/resolver.json
+++ b/packages/design-tokens/raws/resolver.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+    "name": "vapor",
+    "version": "2025.10",
+    "resolutionOrder": [{ "$ref": "#/sets/foundation" }, { "$ref": "#/modifiers/theme" }],
+    "sets": {
+        "foundation": {
+            "sources": [
+                { "$ref": "border-radius.json" },
+                { "$ref": "dimension.json" },
+                { "$ref": "space.json" },
+                { "$ref": "typography.json" },
+                { "$ref": "text-style.json" },
+                { "$ref": "shadow.json" }
+            ]
+        }
+    },
+    "modifiers": {
+        "theme": {
+            "default": "light",
+            "contexts": {
+                "light": [
+                    { "$ref": "primitive-color.light.json" },
+                    { "$ref": "semantic-color.light.json" }
+                ],
+                "dark": [
+                    { "$ref": "primitive-color.dark.json" },
+                    { "$ref": "semantic-color.dark.json" }
+                ]
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/semantic-color.dark.json
+++ b/packages/design-tokens/raws/semantic-color.dark.json
@@ -1,0 +1,815 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "colors": {
+        "background": {
+            "$type": "color",
+            "primary": {
+                "100": {
+                    "$description": "The subtle primary background to represent status, category, or selection state.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element visually indicating current selection or active state with brand color",
+                                "non-interactive element showing status or category with subtle brand emphasis",
+                                "background of element conveying feedback or notification with brand color"
+                            ],
+                            "avoid": [
+                                "page or screen background → colors.background.canvas.100",
+                                "solid action elements background → colors.background.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.050}"
+                },
+                "200": {
+                    "$description": "The solid primary background for high-emphasis interactive action and brand-colored elements.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background for interactive elements that require brand color emphasis",
+                                "brand color fill for non-interactive visual elements requiring strong brand presence"
+                            ],
+                            "avoid": [
+                                "page or screen background → colors.background.canvas.100",
+                                "status or category label background → colors.background.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.500}"
+                }
+            },
+            "contrast": {
+                "100": {
+                    "$description": "The subtle contrast background to intentionally draw attention to content by contrasting with the surrounding page surface.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of non-interactive element requiring intentional visual contrast against the page",
+                                "background of informational element that must stand out from the surrounding content"
+                            ],
+                            "avoid": [
+                                "elements requiring stronger visual separation → colors.background.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.800}"
+                },
+                "200": {
+                    "$description": "The solid high-emphasis background for elements requiring strong visual separation from the surrounding UI.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element that must be visually distinct from all surrounding content",
+                                "high-emphasis background for elements requiring immediate user attention",
+                                "background of elements providing temporary or contextual information above the page layer"
+                            ],
+                            "avoid": [
+                                "elements requiring only subtle contrast → colors.background.contrast.100",
+                                "interactive variant-specific backgrounds → use variant-specific background tokens"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.300}"
+                }
+            },
+            "canvas": {
+                "100": {
+                    "$description": "The base-level canvas background for pages and bordered components.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default background of all pages or screens",
+                                "base surface background for components with visible borders"
+                            ],
+                            "avoid": [
+                                "elevated surfaces such as sidebar or panel background → colors.background.canvas.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.background.canvas}"
+                },
+                "200": {
+                    "$description": "The solid secondary canvas background to differentiate background regions within a page.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "secondary page-level background area that needs visual separation from the primary canvas",
+                                "layout region requiring a subtle distinction between background layers without component-level context"
+                            ],
+                            "avoid": [
+                                "direct use as a component background → colors.background.secondary.100",
+                                "primary page background → colors.background.canvas.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.050}"
+                }
+            },
+            "overlay": {
+                "100": {
+                    "$description": "The base background to establish visual elevation for top-level floating components.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of components rendered at the highest elevation, such as dialogs or modal overlays",
+                                "background of floating UI anchored to a trigger, appearing above page content",
+                                "background of transient containers that layer over the main interface"
+                            ],
+                            "avoid": ["non-overlay backgrounds → colors.background.canvas.100"],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.100}"
+                }
+            },
+            "secondary": {
+                "100": {
+                    "$description": "Do not use this token.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "status": "do-not-use",
+                            "reason": "No active use case defined.",
+                            "when": [],
+                            "avoid": []
+                        }
+                    },
+                    "$value": "{colors.gray.050}"
+                },
+                "200": {
+                    "$description": "The solid secondary background for components serving a supplementary role alongside primary elements.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of component serving a secondary role alongside primary-colored elements",
+                                "solid fill background for supplementary interactive elements"
+                            ],
+                            "avoid": [
+                                "standalone components requiring visibility without primary context → colors.background.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.200}"
+                }
+            },
+            "success": {
+                "100": {
+                    "$description": "The subtle success background for elements indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating a successful or completed action",
+                                "subtle positive feedback or confirmation element background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.050}"
+                },
+                "200": {
+                    "$description": "The solid success background for elements indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating a successful or completed action",
+                                "high-emphasis positive feedback or confirmation element background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.500}"
+                }
+            },
+            "warning": {
+                "100": {
+                    "$description": "The subtle warning background for elements requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating an action that requires careful consideration",
+                                "subtle cautionary state background guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.background.danger.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.050}"
+                },
+                "200": {
+                    "$description": "The solid warning background for elements requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating an action that requires careful consideration",
+                                "high-emphasis cautionary state background guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.background.danger.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.500}"
+                }
+            },
+            "danger": {
+                "100": {
+                    "$description": "The subtle danger background for elements indicating destructive or irreversible actions.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating a destructive or irreversible action",
+                                "subtle danger state background for high-risk user actions"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve irreversible risk → colors.background.warning.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.050}"
+                },
+                "200": {
+                    "$description": "The solid danger background for elements indicating destructive or irreversible actions.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating a destructive or irreversible action",
+                                "high-emphasis danger state background for high-risk user actions"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve irreversible risk → colors.background.warning.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.500}"
+                }
+            },
+            "hint": {
+                "100": {
+                    "$description": "The subtle hint background for elements providing general informational content.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element providing general informational content to the user",
+                                "subtle background for non-critical informational elements"
+                            ],
+                            "avoid": [
+                                "elements requiring contrast emphasis against surrounding background → colors.background.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.200}"
+                },
+                "200": {
+                    "$description": "Do not use this token.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "status": "do-not-use",
+                            "reason": "No active use case defined.",
+                            "when": [],
+                            "avoid": []
+                        }
+                    },
+                    "$value": "{colors.gray.600}"
+                }
+            }
+        },
+        "foreground": {
+            "$type": "color",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "gradeRules": {
+                        "100": "Use ONLY on pure white (#ffffff) or transparent backgrounds",
+                        "200": "Use on any surface that is not pure white (#ffffff), including near-white colored backgrounds"
+                    }
+                }
+            },
+            "primary": {
+                "100": {
+                    "$description": "The subtle primary foreground for brand-colored text and icons on white or transparent surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "brand-colored text or icon on white or transparent background",
+                                "subtle brand emphasis without a colored background"
+                            ],
+                            "avoid": [
+                                "use on canvas.200 or surfaces with non-white background color → colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.600}"
+                },
+                "200": {
+                    "$description": "The solid primary foreground for brand-colored text and icons on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "brand-colored text or icon on canvas.200 or a surface with non-white background color",
+                                "strong brand emphasis on a colored background surface"
+                            ],
+                            "avoid": [
+                                "use on white or transparent background → colors.foreground.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.700}"
+                }
+            },
+            "inverse": {
+                "$description": "The inverse foreground for text and icons on backgrounds where white ensures sufficient contrast.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "text or icon on backgrounds where white provides sufficient contrast against the background color"
+                        ],
+                        "avoid": [
+                            "light or pale backgrounds where dark text provides better readability → use contextual foreground tokens"
+                        ],
+                        "accessibility": {
+                            "role": "foreground",
+                            "minimumContrast": "4.5:1"
+                        }
+                    }
+                },
+                "$value": "{colors.white}"
+            },
+            "danger": {
+                "100": {
+                    "$description": "The subtle danger foreground for text and icons indicating destructive actions or error states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a destructive or irreversible action such as deletion",
+                                "error message text or icon requiring user attention"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve danger → colors.foreground.warning.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.600}"
+                },
+                "200": {
+                    "$description": "The solid danger foreground for text and icons indicating destructive actions or error states on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a destructive or irreversible action on a non-white background",
+                                "error message text or icon on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "use on white or transparent background → colors.foreground.danger.100",
+                                "cautionary actions that do not involve danger → colors.foreground.warning.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.700}"
+                }
+            },
+            "hint": {
+                "100": {
+                    "$description": "The subtle hint foreground for text and icons in supplementary contexts where low emphasis is intended.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon in an empty or inactive state requiring minimal visual weight",
+                                "supplementary or helper text that needs to be perceived but not emphasized",
+                                "low-emphasis icon in a non-interactive context"
+                            ],
+                            "avoid": [
+                                "elements requiring emphasis → colors.foreground.normal.100 or colors.foreground.primary.100",
+                                "selected or active state text → colors.foreground.normal.100 or colors.foreground.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.600}"
+                },
+                "200": {
+                    "$description": "The solid hint foreground for text and icons in supplementary contexts on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "placeholder or supplementary text on non-white or colored background",
+                                "low-emphasis text or icon on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "elements requiring emphasis → colors.foreground.normal.200 or colors.foreground.primary.200",
+                                "selected or active state text → colors.foreground.normal.200 or colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.700}"
+                }
+            },
+            "normal": {
+                "100": {
+                    "$description": "The subtle normal foreground for default text and icons that users must perceive without brand color emphasis.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default body text or label on white or transparent background",
+                                "essential text or icon that requires clear readability without brand color",
+                                "primary content text where neutral emphasis is sufficient"
+                            ],
+                            "avoid": [
+                                "supplementary or low-emphasis text → colors.foreground.hint.100",
+                                "brand-colored emphasis text → colors.foreground.primary.100",
+                                "highest-hierarchy title or heading requiring maximum visual prominence → colors.foreground.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.700}"
+                },
+                "200": {
+                    "$description": "The solid normal foreground for default text and icons that users must perceive on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default body text or label on canvas.200 or non-white background",
+                                "essential text or icon requiring clear readability on a colored surface"
+                            ],
+                            "avoid": [
+                                "supplementary or low-emphasis text → colors.foreground.hint.200",
+                                "brand-colored emphasis text → colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.900}"
+                }
+            },
+            "secondary": {
+                "100": {
+                    "$description": "The subtle secondary foreground for text and icons with supplementary emphasis.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon with lower visual hierarchy than the primary content on the same surface",
+                                "supplementary or descriptive text supporting a higher-hierarchy text element"
+                            ],
+                            "avoid": [
+                                "standalone elements requiring visibility without primary context → colors.foreground.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.700}"
+                },
+                "200": {
+                    "$description": "The solid secondary foreground for text and icons with supplementary emphasis on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon with lower visual hierarchy than the primary content on a non-white background",
+                                "supplementary or descriptive text supporting a higher-hierarchy text element on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "standalone elements requiring visibility without primary context → colors.foreground.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.900}"
+                }
+            },
+            "success": {
+                "100": {
+                    "$description": "The subtle success foreground for text and icons indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a successful or completed action on white or transparent background",
+                                "positive feedback or confirmation message text or icon"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.600}"
+                },
+                "200": {
+                    "$description": "The solid success foreground for text and icons indicating positive or completed states on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a successful or completed action on canvas.200 or non-white background",
+                                "positive feedback or confirmation message text or icon on colored surface"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.700}"
+                }
+            },
+            "warning": {
+                "100": {
+                    "$description": "The subtle warning foreground for text and icons requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating an action that requires careful consideration on white or transparent background",
+                                "cautionary message text or icon guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.foreground.danger.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.600}"
+                },
+                "200": {
+                    "$description": "The solid warning foreground for text and icons requiring cautious user decision on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating an action that requires careful consideration on canvas.200 or non-white background",
+                                "cautionary message text or icon on colored surface"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.foreground.danger.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.700}"
+                }
+            },
+            "contrast": {
+                "100": {
+                    "$description": "The subtle contrast foreground for text and icons requiring visibility without primary context.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "highest-hierarchy title or heading text requiring maximum visual prominence on the page",
+                                "text or icon requiring clear visibility without accompanying primary-colored elements on white or transparent background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.200}"
+                },
+                "200": {
+                    "$description": "The solid contrast foreground for text and icons requiring visibility without primary context on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon requiring clear visibility without accompanying primary-colored elements on canvas.200 or non-white background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.300}"
+                }
+            }
+        },
+        "border": {
+            "$type": "color",
+            "normal": {
+                "$description": "The base border for default outlines and structural boundaries of UI elements.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "default border for standard UI elements requiring a subtle structural boundary",
+                            "divider or separator between content areas that need visual separation without emphasis"
+                        ],
+                        "avoid": [
+                            "borders conveying interactive variant styles → use variant-specific border tokens (colors.border.primary, colors.border.secondary, colors.border.contrast)"
+                        ],
+                        "accessibility": {
+                            "role": "border"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.300}"
+            },
+            "contrast": {
+                "$description": "The base high-contrast border for focused states and contrast-level outline styles.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of non-text-input interactive elements such as select, button in focused state via interaction layer",
+                            "border of UI elements requiring high contrast outline style"
+                        ],
+                        "avoid": [
+                            "focused state border of input-type elements → colors.border.primary",
+                            "non-contrast variant outline styles → use variant-specific border tokens (colors.border.primary, colors.border.secondary)"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.400}"
+            },
+            "primary": {
+                "$description": "The base primary border for focused states of input-type interactive elements.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": ["border of text input or textarea elements in focused state"],
+                        "avoid": [
+                            "focused state of non-input interactive elements → colors.border.contrast",
+                            "default (unfocused) border of input elements → colors.border.normal"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.blue.400}"
+            },
+            "secondary": {
+                "$description": "The base secondary border for UI elements requiring supplementary boundary emphasis.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of elements serving a secondary role alongside primary interactive elements"
+                        ],
+                        "avoid": [],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.200}"
+            },
+            "success": {
+                "$description": "The base success border for elements indicating positive or completed states.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating a successful or completed action",
+                            "border conveying a positive result to the user"
+                        ],
+                        "avoid": [
+                            "primary action elements → colors.border.primary",
+                            "elements used alongside primary elements → colors.border.secondary"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.green.400}"
+            },
+            "warning": {
+                "$description": "The base warning border for elements requiring cautious user decision.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating an action that requires careful consideration",
+                            "border conveying a cautionary state to guide deliberate user decision"
+                        ],
+                        "avoid": ["irreversible or destructive actions → colors.border.danger"],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.orange.400}"
+            },
+            "hint": {
+                "$description": "The base hint border for elements that visually imply clickable or tappable interaction.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element that visually implies clickable or tappable interaction"
+                        ],
+                        "avoid": ["non-interactive elements → colors.border.normal"],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "4.5:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.400}"
+            },
+            "danger": {
+                "$description": "The base danger border for elements indicating destructive or irreversible actions and error states.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating a destructive or irreversible action",
+                            "border conveying an error state to the user"
+                        ],
+                        "avoid": [
+                            "cautionary actions that do not involve irreversible risk → colors.border.warning"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.red.400}"
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/semantic-color.light.json
+++ b/packages/design-tokens/raws/semantic-color.light.json
@@ -1,0 +1,815 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "colors": {
+        "background": {
+            "$type": "color",
+            "primary": {
+                "100": {
+                    "$description": "The subtle primary background to represent status, category, or selection state.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element visually indicating current selection or active state with brand color",
+                                "non-interactive element showing status or category with subtle brand emphasis",
+                                "background of element conveying feedback or notification with brand color"
+                            ],
+                            "avoid": [
+                                "page or screen background → colors.background.canvas.100",
+                                "solid action elements background → colors.background.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.100}"
+                },
+                "200": {
+                    "$description": "The solid primary background for high-emphasis interactive action and brand-colored elements.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background for interactive elements that require brand color emphasis",
+                                "brand color fill for non-interactive visual elements requiring strong brand presence"
+                            ],
+                            "avoid": [
+                                "page or screen background → colors.background.canvas.100",
+                                "status or category label background → colors.background.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.500}"
+                }
+            },
+            "contrast": {
+                "100": {
+                    "$description": "The subtle contrast background to intentionally draw attention to content by contrasting with the surrounding page surface.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of non-interactive element requiring intentional visual contrast against the page",
+                                "background of informational element that must stand out from the surrounding content"
+                            ],
+                            "avoid": [
+                                "elements requiring stronger visual separation → colors.background.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.300}"
+                },
+                "200": {
+                    "$description": "The solid high-emphasis background for elements requiring strong visual separation from the surrounding UI.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element that must be visually distinct from all surrounding content",
+                                "high-emphasis background for elements requiring immediate user attention",
+                                "background of elements providing temporary or contextual information above the page layer"
+                            ],
+                            "avoid": [
+                                "elements requiring only subtle contrast → colors.background.contrast.100",
+                                "interactive variant-specific backgrounds → use variant-specific background tokens"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.800}"
+                }
+            },
+            "canvas": {
+                "100": {
+                    "$description": "The base-level canvas background for pages and bordered components.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default background of all pages or screens",
+                                "base surface background for components with visible borders"
+                            ],
+                            "avoid": [
+                                "elevated surfaces such as sidebar or panel background → colors.background.canvas.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.background.canvas}"
+                },
+                "200": {
+                    "$description": "The solid secondary canvas background to differentiate background regions within a page.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "secondary page-level background area that needs visual separation from the primary canvas",
+                                "layout region requiring a subtle distinction between background layers without component-level context"
+                            ],
+                            "avoid": [
+                                "direct use as a component background → colors.background.secondary.100",
+                                "primary page background → colors.background.canvas.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.050}"
+                }
+            },
+            "overlay": {
+                "100": {
+                    "$description": "The base background to establish visual elevation for top-level floating components.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of components rendered at the highest elevation, such as dialogs or modal overlays",
+                                "background of floating UI anchored to a trigger, appearing above page content",
+                                "background of transient containers that layer over the main interface"
+                            ],
+                            "avoid": ["non-overlay backgrounds → colors.background.canvas.100"],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.white}"
+                }
+            },
+            "secondary": {
+                "100": {
+                    "$description": "Do not use this token.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "status": "do-not-use",
+                            "reason": "No active use case defined.",
+                            "when": [],
+                            "avoid": []
+                        }
+                    },
+                    "$value": "{colors.gray.050}"
+                },
+                "200": {
+                    "$description": "The solid secondary background for components serving a supplementary role alongside primary elements.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of component serving a secondary role alongside primary-colored elements",
+                                "solid fill background for supplementary interactive elements"
+                            ],
+                            "avoid": [
+                                "standalone components requiring visibility without primary context → colors.background.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.100}"
+                }
+            },
+            "success": {
+                "100": {
+                    "$description": "The subtle success background for elements indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating a successful or completed action",
+                                "subtle positive feedback or confirmation element background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.100}"
+                },
+                "200": {
+                    "$description": "The solid success background for elements indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating a successful or completed action",
+                                "high-emphasis positive feedback or confirmation element background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.500}"
+                }
+            },
+            "warning": {
+                "100": {
+                    "$description": "The subtle warning background for elements requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating an action that requires careful consideration",
+                                "subtle cautionary state background guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.background.danger.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.100}"
+                },
+                "200": {
+                    "$description": "The solid warning background for elements requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating an action that requires careful consideration",
+                                "high-emphasis cautionary state background guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.background.danger.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.500}"
+                }
+            },
+            "danger": {
+                "100": {
+                    "$description": "The subtle danger background for elements indicating destructive or irreversible actions.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element indicating a destructive or irreversible action",
+                                "subtle danger state background for high-risk user actions"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve irreversible risk → colors.background.warning.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.100}"
+                },
+                "200": {
+                    "$description": "The solid danger background for elements indicating destructive or irreversible actions.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "solid fill background of element indicating a destructive or irreversible action",
+                                "high-emphasis danger state background for high-risk user actions"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve irreversible risk → colors.background.warning.200"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.500}"
+                }
+            },
+            "hint": {
+                "100": {
+                    "$description": "The subtle hint background for elements providing general informational content.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "background of element providing general informational content to the user",
+                                "subtle background for non-critical informational elements"
+                            ],
+                            "avoid": [
+                                "elements requiring contrast emphasis against surrounding background → colors.background.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "background"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.100}"
+                },
+                "200": {
+                    "$description": "Do not use this token.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "status": "do-not-use",
+                            "reason": "No active use case defined.",
+                            "when": [],
+                            "avoid": []
+                        }
+                    },
+                    "$value": "{colors.gray.600}"
+                }
+            }
+        },
+        "foreground": {
+            "$type": "color",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "gradeRules": {
+                        "100": "Use ONLY on pure white (#ffffff) or transparent backgrounds",
+                        "200": "Use on any surface that is not pure white (#ffffff), including near-white colored backgrounds"
+                    }
+                }
+            },
+            "primary": {
+                "100": {
+                    "$description": "The subtle primary foreground for brand-colored text and icons on white or transparent surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "brand-colored text or icon on white or transparent background",
+                                "subtle brand emphasis without a colored background"
+                            ],
+                            "avoid": [
+                                "use on canvas.200 or surfaces with non-white background color → colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.600}"
+                },
+                "200": {
+                    "$description": "The solid primary foreground for brand-colored text and icons on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "brand-colored text or icon on canvas.200 or a surface with non-white background color",
+                                "strong brand emphasis on a colored background surface"
+                            ],
+                            "avoid": [
+                                "use on white or transparent background → colors.foreground.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.blue.700}"
+                }
+            },
+            "inverse": {
+                "$description": "The inverse foreground for text and icons on backgrounds where white ensures sufficient contrast.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "text or icon on backgrounds where white provides sufficient contrast against the background color"
+                        ],
+                        "avoid": [
+                            "light or pale backgrounds where dark text provides better readability → use contextual foreground tokens"
+                        ],
+                        "accessibility": {
+                            "role": "foreground",
+                            "minimumContrast": "4.5:1"
+                        }
+                    }
+                },
+                "$value": "{colors.white}"
+            },
+            "danger": {
+                "100": {
+                    "$description": "The subtle danger foreground for text and icons indicating destructive actions or error states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a destructive or irreversible action such as deletion",
+                                "error message text or icon requiring user attention"
+                            ],
+                            "avoid": [
+                                "cautionary actions that do not involve danger → colors.foreground.warning.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.600}"
+                },
+                "200": {
+                    "$description": "The solid danger foreground for text and icons indicating destructive actions or error states on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a destructive or irreversible action on a non-white background",
+                                "error message text or icon on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "use on white or transparent background → colors.foreground.danger.100",
+                                "cautionary actions that do not involve danger → colors.foreground.warning.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.red.700}"
+                }
+            },
+            "hint": {
+                "100": {
+                    "$description": "The subtle hint foreground for text and icons in supplementary contexts where low emphasis is intended.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon in an empty or inactive state requiring minimal visual weight",
+                                "supplementary or helper text that needs to be perceived but not emphasized",
+                                "low-emphasis icon in a non-interactive context"
+                            ],
+                            "avoid": [
+                                "elements requiring emphasis → colors.foreground.normal.100 or colors.foreground.primary.100",
+                                "selected or active state text → colors.foreground.normal.100 or colors.foreground.primary.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.600}"
+                },
+                "200": {
+                    "$description": "The solid hint foreground for text and icons in supplementary contexts on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "placeholder or supplementary text on non-white or colored background",
+                                "low-emphasis text or icon on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "elements requiring emphasis → colors.foreground.normal.200 or colors.foreground.primary.200",
+                                "selected or active state text → colors.foreground.normal.200 or colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.700}"
+                }
+            },
+            "normal": {
+                "100": {
+                    "$description": "The subtle normal foreground for default text and icons that users must perceive without brand color emphasis.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default body text or label on white or transparent background",
+                                "essential text or icon that requires clear readability without brand color",
+                                "primary content text where neutral emphasis is sufficient"
+                            ],
+                            "avoid": [
+                                "supplementary or low-emphasis text → colors.foreground.hint.100",
+                                "brand-colored emphasis text → colors.foreground.primary.100",
+                                "highest-hierarchy title or heading requiring maximum visual prominence → colors.foreground.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.700}"
+                },
+                "200": {
+                    "$description": "The solid normal foreground for default text and icons that users must perceive on colored background surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "default body text or label on canvas.200 or non-white background",
+                                "essential text or icon requiring clear readability on a colored surface"
+                            ],
+                            "avoid": [
+                                "supplementary or low-emphasis text → colors.foreground.hint.200",
+                                "brand-colored emphasis text → colors.foreground.primary.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.900}"
+                }
+            },
+            "secondary": {
+                "100": {
+                    "$description": "The subtle secondary foreground for text and icons with supplementary emphasis.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon with lower visual hierarchy than the primary content on the same surface",
+                                "supplementary or descriptive text supporting a higher-hierarchy text element"
+                            ],
+                            "avoid": [
+                                "standalone elements requiring visibility without primary context → colors.foreground.contrast.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.800}"
+                },
+                "200": {
+                    "$description": "The solid secondary foreground for text and icons with supplementary emphasis on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon with lower visual hierarchy than the primary content on a non-white background",
+                                "supplementary or descriptive text supporting a higher-hierarchy text element on canvas.200 or tinted surface"
+                            ],
+                            "avoid": [
+                                "standalone elements requiring visibility without primary context → colors.foreground.contrast.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.900}"
+                }
+            },
+            "success": {
+                "100": {
+                    "$description": "The subtle success foreground for text and icons indicating positive or completed states.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a successful or completed action on white or transparent background",
+                                "positive feedback or confirmation message text or icon"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.600}"
+                },
+                "200": {
+                    "$description": "The solid success foreground for text and icons indicating positive or completed states on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating a successful or completed action on canvas.200 or non-white background",
+                                "positive feedback or confirmation message text or icon on colored surface"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.green.700}"
+                }
+            },
+            "warning": {
+                "100": {
+                    "$description": "The subtle warning foreground for text and icons requiring cautious user decision.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating an action that requires careful consideration on white or transparent background",
+                                "cautionary message text or icon guiding deliberate user decision"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.foreground.danger.100"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.600}"
+                },
+                "200": {
+                    "$description": "The solid warning foreground for text and icons requiring cautious user decision on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon indicating an action that requires careful consideration on canvas.200 or non-white background",
+                                "cautionary message text or icon on colored surface"
+                            ],
+                            "avoid": [
+                                "irreversible or destructive actions → colors.foreground.danger.200"
+                            ],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.orange.700}"
+                }
+            },
+            "contrast": {
+                "100": {
+                    "$description": "The subtle contrast foreground for text and icons requiring visibility without primary context.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "highest-hierarchy title or heading text requiring maximum visual prominence on the page",
+                                "text or icon requiring clear visibility without accompanying primary-colored elements on white or transparent background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.800}"
+                },
+                "200": {
+                    "$description": "The solid contrast foreground for text and icons requiring visibility without primary context on colored surfaces.",
+                    "$extensions": {
+                        "io.goorm.vapor": {
+                            "when": [
+                                "text or icon requiring clear visibility without accompanying primary-colored elements on canvas.200 or non-white background"
+                            ],
+                            "avoid": [],
+                            "accessibility": {
+                                "role": "foreground",
+                                "minimumContrast": "4.5:1"
+                            }
+                        }
+                    },
+                    "$value": "{colors.gray.800}"
+                }
+            }
+        },
+        "border": {
+            "$type": "color",
+            "normal": {
+                "$description": "The base border for default outlines and structural boundaries of UI elements.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "default border for standard UI elements requiring a subtle structural boundary",
+                            "divider or separator between content areas that need visual separation without emphasis"
+                        ],
+                        "avoid": [
+                            "borders conveying interactive variant styles → use variant-specific border tokens (colors.border.primary, colors.border.secondary, colors.border.contrast)"
+                        ],
+                        "accessibility": {
+                            "role": "border"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.100}"
+            },
+            "contrast": {
+                "$description": "The base high-contrast border for focused states and contrast-level outline styles.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of non-text-input interactive elements such as select, button in focused state via interaction layer",
+                            "border of UI elements requiring high contrast outline style"
+                        ],
+                        "avoid": [
+                            "focused state border of input-type elements → colors.border.primary",
+                            "non-contrast variant outline styles → use variant-specific border tokens (colors.border.primary, colors.border.secondary)"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.800}"
+            },
+            "primary": {
+                "$description": "The base primary border for focused states of input-type interactive elements.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": ["border of text input or textarea elements in focused state"],
+                        "avoid": [
+                            "focused state of non-input interactive elements → colors.border.contrast",
+                            "default (unfocused) border of input elements → colors.border.normal"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.blue.500}"
+            },
+            "secondary": {
+                "$description": "The base secondary border for UI elements requiring supplementary boundary emphasis.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of elements serving a secondary role alongside primary interactive elements"
+                        ],
+                        "avoid": [],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.200}"
+            },
+            "success": {
+                "$description": "The base success border for elements indicating positive or completed states.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating a successful or completed action",
+                            "border conveying a positive result to the user"
+                        ],
+                        "avoid": [
+                            "primary action elements → colors.border.primary",
+                            "elements used alongside primary elements → colors.border.secondary"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.green.500}"
+            },
+            "warning": {
+                "$description": "The base warning border for elements requiring cautious user decision.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating an action that requires careful consideration",
+                            "border conveying a cautionary state to guide deliberate user decision"
+                        ],
+                        "avoid": ["irreversible or destructive actions → colors.border.danger"],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.orange.500}"
+            },
+            "hint": {
+                "$description": "The base hint border for elements that visually imply clickable or tappable interaction.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element that visually implies clickable or tappable interaction"
+                        ],
+                        "avoid": ["non-interactive elements → colors.border.normal"],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "4.5:1"
+                        }
+                    }
+                },
+                "$value": "{colors.gray.600}"
+            },
+            "danger": {
+                "$description": "The base danger border for elements indicating destructive or irreversible actions and error states.",
+                "$extensions": {
+                    "io.goorm.vapor": {
+                        "when": [
+                            "border of element indicating a destructive or irreversible action",
+                            "border conveying an error state to the user"
+                        ],
+                        "avoid": [
+                            "cautionary actions that do not involve irreversible risk → colors.border.warning"
+                        ],
+                        "accessibility": {
+                            "role": "border",
+                            "minimumContrast": "3:1"
+                        }
+                    }
+                },
+                "$value": "{colors.red.500}"
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/shadow.json
+++ b/packages/design-tokens/raws/shadow.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "shadow": {
+        "$type": "shadow",
+        "sm": {
+            "$description": "Do not use — no active use case defined.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "status": "do-not-use",
+                    "reason": "No active use case defined.",
+                    "when": [],
+                    "avoid": []
+                }
+            },
+            "$value": {
+                "offsetX": { "value": 0, "unit": "px" },
+                "offsetY": { "value": 1, "unit": "px" },
+                "blur": { "value": 3, "unit": "px" },
+                "spread": { "value": 0, "unit": "px" },
+                "color": "rgba(0, 0, 0, 0.2)"
+            }
+        },
+        "md": {
+            "$description": "The most common shadow. Used when an interface element requires clear separation from the background.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "independent element requiring user action",
+                        "element that must be perceived first by the user",
+                        "element temporarily emphasized by interaction such as focus or selection"
+                    ],
+                    "avoid": ["icons", "text"]
+                }
+            },
+            "$value": {
+                "offsetX": { "value": 0, "unit": "px" },
+                "offsetY": { "value": 4, "unit": "px" },
+                "blur": { "value": 10, "unit": "px" },
+                "spread": { "value": 0, "unit": "px" },
+                "color": "rgba(0, 0, 0, 0.2)"
+            }
+        },
+        "lg": {
+            "$description": "Represents a higher elevation than `md`. Used when separation from an interface element that already has a shadow applied is required.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["element that appears above another element with a shadow applied"],
+                    "avoid": ["general shadow use → `md`"]
+                }
+            },
+            "$value": {
+                "offsetX": { "value": 0, "unit": "px" },
+                "offsetY": { "value": 4, "unit": "px" },
+                "blur": { "value": 16, "unit": "px" },
+                "spread": { "value": 0, "unit": "px" },
+                "color": "rgba(0, 0, 0, 0.2)"
+            }
+        },
+        "xl": {
+            "$description": "Used for the strongest separation between page and content. Represents the greatest perceived distance between elements.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["modal-type overlay content that appears above the page"],
+                    "avoid": ["elements that are not overlay content"]
+                }
+            },
+            "$value": {
+                "offsetX": { "value": 0, "unit": "px" },
+                "offsetY": { "value": 16, "unit": "px" },
+                "blur": { "value": 32, "unit": "px" },
+                "spread": { "value": 0, "unit": "px" },
+                "color": "rgba(0, 0, 0, 0.2)"
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/space.json
+++ b/packages/design-tokens/raws/space.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "size": {
+        "space": {
+            "$type": "dimension",
+            "$description": "Scale for spacing properties such as padding and gap. The number is a scale index, not a px value.",
+            "000": { "$value": { "value": 0, "unit": "px" } },
+            "025": { "$value": { "value": 2, "unit": "px" } },
+            "050": { "$value": { "value": 4, "unit": "px" } },
+            "075": { "$value": { "value": 6, "unit": "px" } },
+            "100": { "$value": { "value": 8, "unit": "px" } },
+            "150": { "$value": { "value": 12, "unit": "px" } },
+            "175": { "$value": { "value": 14, "unit": "px" } },
+            "200": { "$value": { "value": 16, "unit": "px" } },
+            "225": { "$value": { "value": 18, "unit": "px" } },
+            "250": { "$value": { "value": 20, "unit": "px" } },
+            "300": { "$value": { "value": 24, "unit": "px" } },
+            "400": { "$value": { "value": 32, "unit": "px" } },
+            "500": { "$value": { "value": 40, "unit": "px" } },
+            "600": { "$value": { "value": 48, "unit": "px" } },
+            "700": { "$value": { "value": 56, "unit": "px" } },
+            "800": { "$value": { "value": 64, "unit": "px" } },
+            "900": { "$value": { "value": 72, "unit": "px" } }
+        }
+    }
+}

--- a/packages/design-tokens/raws/text-style.json
+++ b/packages/design-tokens/raws/text-style.json
@@ -1,0 +1,344 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "textStyle": {
+        "$type": "typography",
+        "display1": {
+            "$description": "The largest text style in the system. Recommended for use as a graphic element rather than readable text.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "hero section or marketing content headline on a landing page at the largest display scale"
+                    ],
+                    "avoid": [
+                        "mobile viewports → display2 or display3",
+                        "text requiring readability → display2 or display3"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.800}",
+                "fontSize": "{typography.fontSize.1000}",
+                "lineHeight": "{typography.lineHeight.1000}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "display2": {
+            "$description": "The largest readable display scale. Recommended for delivering strong marketing messages.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["hero section or marketing content headline on a landing page"],
+                    "avoid": [
+                        "mobile viewports → display4 or heading1",
+                        "more than one instance per page"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.800}",
+                "fontSize": "{typography.fontSize.900}",
+                "lineHeight": "{typography.lineHeight.900}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "display3": {
+            "$description": "The default readable display scale.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "hero section or marketing content headline on a landing page at medium display scale"
+                    ],
+                    "avoid": [
+                        "mobile viewports → display4 or heading1",
+                        "more than one instance per page"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.800}",
+                "fontSize": "{typography.fontSize.800}",
+                "lineHeight": "{typography.lineHeight.800}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "display4": {
+            "$description": "The smallest readable display scale. Can be applied to subsection titles when display2 or display3 is used on the same page.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "hero section or marketing content headline on a landing page at the smallest display scale",
+                        "subsection title beneath a display2 or display3 headline"
+                    ],
+                    "avoid": ["mobile viewports → heading1 or heading2"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.800}",
+                "fontSize": "{typography.fontSize.700}",
+                "lineHeight": "{typography.lineHeight.700}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "heading1": {
+            "$description": "The default section title scale for landing pages.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["section title on a landing page"],
+                    "avoid": [
+                        "general product UI → heading2 or heading3",
+                        "mobile viewports → heading2 or heading3"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.700}",
+                "fontSize": "{typography.fontSize.600}",
+                "lineHeight": "{typography.lineHeight.600}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "heading2": {
+            "$description": "The largest page title scale in general product UI. Recommended for delivering a specific message rather than a generic title.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "welcome message on an AI product home screen",
+                        "page title in a general product UI requiring stronger emphasis than heading3"
+                    ],
+                    "avoid": ["general informational page titles → heading3"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.700}",
+                "fontSize": "{typography.fontSize.500}",
+                "lineHeight": "{typography.lineHeight.500}",
+                "letterSpacing": "{typography.letterSpacing.400}"
+            }
+        },
+        "heading3": {
+            "$description": "The default page title scale in general product UI. Can be applied as a subtitle when heading1 or heading2 is used as the primary title.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "primary page title in a general product UI",
+                        "subtitle beneath heading1 or heading2"
+                    ],
+                    "avoid": ["marketing or high-emphasis messages → heading2"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.700}",
+                "fontSize": "{typography.fontSize.400}",
+                "lineHeight": "{typography.lineHeight.400}",
+                "letterSpacing": "{typography.letterSpacing.300}"
+            }
+        },
+        "heading4": {
+            "$description": "The smallest page title scale and the largest component title scale in general product UI.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "subtitle beneath a page title",
+                        "title of a dialog, card, or side navigation at the largest component heading scale"
+                    ],
+                    "avoid": ["primary page main title → heading3"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.700}",
+                "fontSize": "{typography.fontSize.300}",
+                "lineHeight": "{typography.lineHeight.300}",
+                "letterSpacing": "{typography.letterSpacing.200}"
+            }
+        },
+        "heading5": {
+            "$description": "The default component title scale for dialogs, cards, and side navigation.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "title of a dialog, card, or side navigation at the default component heading scale"
+                    ],
+                    "avoid": ["primary page main title → heading3"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.700}",
+                "fontSize": "{typography.fontSize.200}",
+                "lineHeight": "{typography.lineHeight.200}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "heading6": {
+            "$description": "The smallest component title scale for dialogs, cards, and side navigation. Also used as a label for extra-large components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "title of a dialog, card, or side navigation at the smallest component heading scale",
+                        "label for an extra-large component"
+                    ],
+                    "avoid": ["cases requiring bold emphasis → heading5"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.500}",
+                "fontSize": "{typography.fontSize.100}",
+                "lineHeight": "{typography.lineHeight.100}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "subtitle1": {
+            "$description": "The default label scale. Used as a general label or for medium and large components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["general label or label for medium and large components"],
+                    "avoid": ["body or paragraph text → body2"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.500}",
+                "fontSize": "{typography.fontSize.075}",
+                "lineHeight": "{typography.lineHeight.075}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "subtitle2": {
+            "$description": "The smallest label scale. Used as a supporting label beneath heading6 or subtitle1, or for small components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["supporting label or label for small components"],
+                    "avoid": ["standalone use without accompanying text or component → subtitle1"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.500}",
+                "fontSize": "{typography.fontSize.050}",
+                "lineHeight": "{typography.lineHeight.050}",
+                "letterSpacing": "{typography.letterSpacing.000}"
+            }
+        },
+        "body1": {
+            "$description": "Recommended as supporting text for heading3 or heading4. Used for descriptive text in large components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "supporting text beneath heading3 or heading4",
+                        "placeholder text in an extra-large component"
+                    ],
+                    "avoid": ["supporting text for heading5 or heading6 → body2 or body3"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.100}",
+                "lineHeight": "{typography.lineHeight.100}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "body2": {
+            "$description": "The default body text scale. Used for descriptive text in medium and large components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "body or paragraph text",
+                        "placeholder text in medium or large components",
+                        "menu item or field description"
+                    ],
+                    "avoid": ["labels → subtitle1"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.075}",
+                "lineHeight": "{typography.lineHeight.075}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "body3": {
+            "$description": "The default caption scale. Used for descriptive text explaining titles, body, or images, and for small components.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": [
+                        "placeholder text in a small component",
+                        "caption text describing a title, body, or image"
+                    ],
+                    "avoid": ["standalone use without accompanying text or component → body2"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.050}",
+                "lineHeight": "{typography.lineHeight.050}",
+                "letterSpacing": "{typography.letterSpacing.100}"
+            }
+        },
+        "body4": {
+            "$description": "The smallest caption scale. Readability is not guaranteed; use sparingly.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["caption text in space-constrained contexts"],
+                    "avoid": ["captions users must read without difficulty → body3"]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.sans}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.025}",
+                "lineHeight": "{typography.lineHeight.025}",
+                "letterSpacing": "{typography.letterSpacing.000}"
+            }
+        },
+        "code1": {
+            "$description": "The default code text scale.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["code block or inline code at the default code scale"],
+                    "avoid": [
+                        "non-code text → body2",
+                        "replacing with sans-serif style is not permitted → always use fontFamily.code"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.code}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.075}",
+                "lineHeight": "{typography.lineHeight.075}",
+                "letterSpacing": "{typography.letterSpacing.000}"
+            }
+        },
+        "code2": {
+            "$description": "The smallest code text scale.",
+            "$extensions": {
+                "io.goorm.vapor": {
+                    "when": ["code block or inline code at the smallest code scale"],
+                    "avoid": [
+                        "large screen contexts → code1",
+                        "non-code text → body3",
+                        "replacing with sans-serif style is not permitted → always use fontFamily.code"
+                    ]
+                }
+            },
+            "$value": {
+                "fontFamily": "{typography.fontFamily.code}",
+                "fontWeight": "{typography.fontWeight.400}",
+                "fontSize": "{typography.fontSize.050}",
+                "lineHeight": "{typography.lineHeight.050}",
+                "letterSpacing": "{typography.letterSpacing.000}"
+            }
+        }
+    }
+}

--- a/packages/design-tokens/raws/typography.json
+++ b/packages/design-tokens/raws/typography.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+    "typography": {
+        "fontFamily": {
+            "$type": "fontFamily",
+            "sans": { "$value": ["Pretendard", "sans-serif"] },
+            "code": { "$value": ["FiraCode", "monospace"] }
+        },
+        "fontWeight": {
+            "$type": "fontWeight",
+            "$description": "Font weight scale.",
+            "400": { "$value": 400 },
+            "500": { "$value": 500 },
+            "700": { "$value": 700 },
+            "800": { "$value": 800 }
+        },
+        "fontSize": {
+            "$type": "dimension",
+            "$description": "Font size scale. The number is a scale index, not a px value.",
+            "025": { "$value": { "value": 10, "unit": "px" } },
+            "050": { "$value": { "value": 12, "unit": "px" } },
+            "075": { "$value": { "value": 14, "unit": "px" } },
+            "100": { "$value": { "value": 16, "unit": "px" } },
+            "200": { "$value": { "value": 18, "unit": "px" } },
+            "300": { "$value": { "value": 20, "unit": "px" } },
+            "400": { "$value": { "value": 24, "unit": "px" } },
+            "500": { "$value": { "value": 32, "unit": "px" } },
+            "600": { "$value": { "value": 38, "unit": "px" } },
+            "700": { "$value": { "value": 48, "unit": "px" } },
+            "800": { "$value": { "value": 64, "unit": "px" } },
+            "900": { "$value": { "value": 80, "unit": "px" } },
+            "1000": { "$value": { "value": 120, "unit": "px" } }
+        },
+        "lineHeight": {
+            "$type": "number",
+            "$description": "Line height scale. The number is a scale index, not a px value.",
+            "025": { "$value": 1.4 },
+            "050": { "$value": 1.5 },
+            "075": { "$value": 1.57142 },
+            "100": { "$value": 1.5 },
+            "200": { "$value": 1.44444 },
+            "300": { "$value": 1.5 },
+            "400": { "$value": 1.5 },
+            "500": { "$value": 1.5 },
+            "600": { "$value": 1.47368 },
+            "700": { "$value": 1.2916 },
+            "800": { "$value": 1.3125 },
+            "900": { "$value": 1.3 },
+            "1000": { "$value": 1.3 }
+        },
+        "letterSpacing": {
+            "$type": "dimension",
+            "$description": "Letter spacing scale. The number is a scale index, not a px value.",
+            "000": { "$value": { "value": 0, "unit": "px" } },
+            "100": { "$value": { "value": -0.1, "unit": "px" } },
+            "200": { "$value": { "value": -0.2, "unit": "px" } },
+            "300": { "$value": { "value": -0.3, "unit": "px" } },
+            "400": { "$value": { "value": -0.4, "unit": "px" } }
+        }
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,10 +267,10 @@ importers:
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-docgen:
         specifier: 3.0.10
-        version: 3.0.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.9)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(mdast-util-mdx@3.0.0)
+        version: 3.0.10(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/estree@1.0.9)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(mdast-util-mdx@3.0.0)
       fumadocs-mdx:
         specifier: 14.3.2
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react@19.2.7)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       fumadocs-typescript:
         specifier: 5.2.6
         version: 5.2.6(a42f767853158b8216f7e0ac773a71a1)
@@ -422,16 +422,16 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+        version: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@6.0.3)
 
   packages/color-generator:
     dependencies:
@@ -462,7 +462,7 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -529,7 +529,7 @@ importers:
         version: 16.0.3(rollup@4.60.4)
       '@storybook/react-vite':
         specifier: 9.1.20
-        version: 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+        version: 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -556,10 +556,10 @@ importers:
         version: 1.5.3(rollup@4.60.4)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.2.2
-        version: 5.2.2(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+        version: 5.2.2(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       '@vitest/browser':
         specifier: ^3.2.6
-        version: 3.2.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)
+        version: 3.2.6(playwright@1.60.0)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)
       '@vitest/coverage-v8':
         specifier: ^3.2.6
         version: 3.2.6(@vitest/browser@3.2.6)(vitest@3.2.6)
@@ -632,7 +632,7 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -642,6 +642,8 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.21)(@vitest/browser@3.2.6)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
+
+  packages/design-tokens: {}
 
   packages/eslint-config:
     dependencies:
@@ -669,13 +671,13 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: ^15.5.19
-        version: 15.5.19(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 15.5.19(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-turbo:
         specifier: ^2.9.16
         version: 2.9.16(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.18)
       eslint-plugin-import-x:
         specifier: ^4.16.2
-        version: 4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
+        version: 4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
@@ -724,7 +726,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -751,7 +753,7 @@ importers:
         version: 19.2.7
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -788,7 +790,7 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -833,7 +835,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1751,8 +1753,8 @@ packages:
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1760,14 +1762,17 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -2819,8 +2824,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -2913,8 +2918,8 @@ packages:
   '@oramacloud/client@2.1.4':
     resolution: {integrity: sha512-uNPFs4wq/iOPbggCwTkVNbIr64Vfd7ZS/h+cricXVnzXWocjDTfJ3wLL4lr0qiSu41g8z+eCAGBqJ30RO2O4AA==}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@oxc-transform/binding-android-arm-eabi@0.124.0':
     resolution: {integrity: sha512-A7r8E94VSRnWlsquGXaW2rmpVcruNOTE4a/7+NCVOtlRUlbmd37bOfv0T47MLIN378uES7yldftCwcVMBG39ig==}
@@ -3554,97 +3559,97 @@ packages:
       '@types/react':
         optional: true
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4552,8 +4557,8 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4719,12 +4724,22 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.63.0':
+    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.59.2':
     resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/scope-manager@8.59.4':
     resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.59.2':
@@ -4745,6 +4760,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/tsconfig-utils@8.63.0':
+    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/type-utils@8.59.4':
     resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4756,12 +4777,12 @@ packages:
     resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.3':
-    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.59.4':
     resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.59.2':
@@ -4772,6 +4793,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.59.4':
     resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.63.0':
+    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -4790,12 +4817,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.63.0':
+    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.59.2':
     resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.59.4':
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -7796,6 +7834,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -7856,6 +7898,10 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -8141,8 +8187,8 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -8766,6 +8812,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -8975,13 +9026,13 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.16:
-    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
+      '@vitejs/devtools': ^0.3.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -11054,9 +11105,9 @@ snapshots:
   '@date-fns/tz@1.4.1':
     optional: true
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
@@ -11071,6 +11122,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
@@ -11081,7 +11137,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11707,13 +11763,13 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))':
+  '@jest/core@30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -11721,14 +11777,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.21)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -11754,7 +11810,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       jest-mock: 30.3.0
 
   '@jest/expect-utils@29.7.0':
@@ -11776,7 +11832,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.2
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -11794,7 +11850,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -11805,7 +11861,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit-x: 0.2.2
@@ -11884,7 +11940,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -11894,7 +11950,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -11907,12 +11963,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
       glob: 10.5.0
       magic-string: 0.30.21
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -12000,18 +12056,18 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@16.2.7': {}
@@ -12072,7 +12128,7 @@ snapshots:
       '@orama/orama': 3.1.18
       lodash: 4.17.21
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.139.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.124.0':
     optional: true
@@ -12122,9 +12178,9 @@ snapshots:
   '@oxc-transform/binding-openharmony-arm64@0.124.0':
     optional: true
 
-  '@oxc-transform/binding-wasm32-wasi@0.124.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-transform/binding-wasm32-wasi@0.124.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12567,53 +12623,53 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
@@ -12992,21 +13048,21 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
 
-  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       ts-dedent: 2.2.0
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
 
   '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)))':
     dependencies:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0))
       unplugin: 1.16.1
 
-  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))':
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -13022,27 +13078,27 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0))
 
-  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))':
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
 
-  '@storybook/react-vite@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@storybook/react-vite@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
-      '@storybook/react': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      '@storybook/react': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)
       find-up: 7.0.0
       magic-string: 0.30.21
       react: 19.2.7
       react-docgen: 8.0.2
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.10
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       tsconfig-paths: 4.2.0
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -13078,13 +13134,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@storybook/react@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)':
+  '@storybook/react@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)))
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
     optionalDependencies:
       typescript: 5.9.3
 
@@ -13383,7 +13439,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -13568,7 +13624,7 @@ snapshots:
   '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.59.4
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13583,6 +13639,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.63.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.63.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2
@@ -13592,6 +13658,12 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/scope-manager@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+    optional: true
 
   '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
     dependencies:
@@ -13604,6 +13676,11 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+    optional: true
 
   '@typescript-eslint/type-utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -13619,9 +13696,10 @@ snapshots:
 
   '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/types@8.59.3': {}
-
   '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/types@8.63.0':
+    optional: true
 
   '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
     dependencies:
@@ -13653,6 +13731,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.8.1
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
@@ -13675,6 +13769,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2
@@ -13684,6 +13790,12 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.63.0':
+    dependencies:
+      '@typescript-eslint/types': 8.63.0
+      eslint-visitor-keys: 5.0.1
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -13855,11 +13967,11 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.20.1
 
-  '@vanilla-extract/vite-plugin@5.2.2(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@vanilla-extract/vite-plugin@5.2.2(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
       '@vanilla-extract/compiler': 0.7.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
       '@vanilla-extract/integration': 8.0.9
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -13956,11 +14068,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)':
+  '@vitest/browser@3.2.6(playwright@1.60.0)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.6(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.6(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       '@vitest/utils': 3.2.6
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -14010,7 +14122,7 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.21)(@vitest/browser@3.2.6)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)
+      '@vitest/browser': 3.2.6(playwright@1.60.0)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))(vitest@3.2.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -14038,13 +14150,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
 
   '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@20.19.43)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
@@ -14062,13 +14174,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.6(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.6(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -15091,7 +15203,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@15.5.19(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@15.5.19(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.19
       '@rushstack/eslint-patch': 1.12.0
@@ -15099,7 +15211,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -15132,7 +15244,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15144,7 +15256,7 @@ snapshots:
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15155,11 +15267,11 @@ snapshots:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.59.2
@@ -15173,7 +15285,7 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
@@ -15586,13 +15698,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-docgen@3.0.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.9)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(mdast-util-mdx@3.0.0):
+  fumadocs-docgen@3.0.10(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/estree@1.0.9)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(mdast-util-mdx@3.0.0):
     dependencies:
       estree-util-to-js: 2.0.0
       estree-util-value-to-estree: 3.5.0
       fumadocs-core: 16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       npm-to-yarn: 3.0.1
-      oxc-transform: 0.124.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-transform: 0.124.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
@@ -15606,7 +15718,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@oramacloud/client@2.1.4)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.14.0(react@19.2.7))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0))(react@19.2.7)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -15632,7 +15744,7 @@ snapshots:
       '@types/react': 19.2.17
       next: 16.2.7(@babel/core@7.28.4)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.99.0)
       react: 19.2.7
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16219,7 +16331,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -16239,15 +16351,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -16258,7 +16370,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -16286,7 +16398,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
       esbuild-register: 3.6.0(esbuild@0.27.7)
-      ts-node: 10.9.2(@types/node@20.19.43)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@20.19.43)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@22.19.21)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.21
+      esbuild-register: 3.6.0(esbuild@0.27.7)
+      ts-node: 10.9.2(@types/node@20.19.43)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -16322,7 +16467,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -16332,7 +16477,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16390,7 +16535,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -16424,7 +16569,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -16453,7 +16598,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       cjs-module-lexer: 2.1.1
       collect-v8-coverage: 1.0.2
@@ -16500,7 +16645,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16509,7 +16654,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -16528,7 +16673,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -16537,18 +16682,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 20.19.43
+      '@types/node': 22.19.21
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17513,7 +17658,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-transform@0.124.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-transform@0.124.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-transform/binding-android-arm-eabi': 0.124.0
       '@oxc-transform/binding-android-arm64': 0.124.0
@@ -17531,7 +17676,7 @@ snapshots:
       '@oxc-transform/binding-linux-x64-gnu': 0.124.0
       '@oxc-transform/binding-linux-x64-musl': 0.124.0
       '@oxc-transform/binding-openharmony-arm64': 0.124.0
-      '@oxc-transform/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-transform/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-transform/binding-win32-arm64-msvc': 0.124.0
       '@oxc-transform/binding-win32-ia32-msvc': 0.124.0
       '@oxc-transform/binding-win32-x64-msvc': 0.124.0
@@ -17655,6 +17800,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
@@ -17683,12 +17830,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.15
+      postcss: 8.5.16
       tsx: 4.21.0
 
   postcss-value-parser@4.2.0: {}
@@ -17700,6 +17847,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -18057,26 +18210,26 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown@1.0.3:
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.139.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rollup-plugin-dts@6.4.1(rollup@4.60.4)(typescript@5.9.3):
     dependencies:
@@ -18466,13 +18619,13 @@ snapshots:
       - utf-8-validate
       - vite
 
-  storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)):
+  storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.4)(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.12
@@ -18742,18 +18895,18 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.1
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -18773,7 +18926,7 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -18787,7 +18940,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -18807,7 +18960,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -18818,7 +18971,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.3
       source-map: 0.7.6
@@ -18827,8 +18980,36 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)(typescript@6.0.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.16)(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.60.3
+      source-map: 0.7.6
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.16
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -18915,6 +19096,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   ufo@1.6.1: {}
 
@@ -19149,7 +19332,7 @@ snapshots:
       es-module-lexer: 2.1.0
       obug: 2.1.2
       pathe: 2.0.3
-      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -19170,7 +19353,7 @@ snapshots:
       es-module-lexer: 2.1.0
       obug: 2.1.2
       pathe: 2.0.3
-      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
+      vite: 8.1.4(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -19240,12 +19423,12 @@ snapshots:
       sass: 1.99.0
       tsx: 4.21.0
 
-  vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0):
+  vite@8.1.4(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.21
@@ -19255,12 +19438,12 @@ snapshots:
       sass: 1.99.0
       tsx: 4.21.0
 
-  vite@8.0.16(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0):
+  vite@8.1.4(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.5.0


### PR DESCRIPTION
## Description of Changes

@coderabbitai summary

- 디자인 토큰의 SSOT가 될 패키지를 생성했습니다.
- 추후 다른 도구들과의 어댑터를 추가할 계획입니다.
- 현재는 JSON을 모아두고, 이를 패키지 외부에서 사용할 수 있도록 Export 경로만 뚫어뒀습니다.

```ts
import borderRadius from '@vapor-ui/design-tokens/raws/border-radius';
import darkSemanticColor from '@vapor-ui/design-tokens/raws/semantic-color.dark';

console.log(borderRadius);
console.log(darkSemanticColor);
```

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
