### PR TITLE
ci(release): migrate npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
             publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
         name: Release
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+            id-token: write # npm trusted publishing (OIDC)
         steps:
             - name: Checkout branch
               uses: actions/checkout@v4
@@ -24,13 +28,10 @@ jobs:
             - name: Install
               uses: ./.github/composite/install
 
-            - name: Create .npmrc file
-              run: |
-                  cat << EOF > "$HOME/.npmrc"
-                    //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-                  EOF
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            # Trusted publishing requires npm >= 11.5.1; the bundled npm depends on
+            # the resolved Node version, so pin the CLI explicitly.
+            - name: Update npm for trusted publishing
+              run: npm install -g npm@latest
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets
@@ -40,9 +41,8 @@ jobs:
                   version: pnpm run version
                   commit: 'ci(changesets): version packages'
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_CONFIG_PROVENANCE: true
 
             - name: Update Release Notes
               if: steps.changesets.outputs.published == 'false'

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -7,6 +7,11 @@
         "jscodeshift",
         "codemod"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/goorm-dev/vapor-ui.git",
+        "directory": "packages/codemod"
+    },
     "main": "dist/src/index.mjs",
     "bin": {
         "vapor-codemod": "./dist/bin/cli.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/goorm-dev/vapor-ui.git",
-        "directory": "packages/react"
+        "directory": "packages/core"
     },
     "license": "MIT",
     "author": "Vapor Team <vapor.ui@goorm.io>",

--- a/packages/eslint-plugin-vapor/package.json
+++ b/packages/eslint-plugin-vapor/package.json
@@ -2,6 +2,11 @@
     "name": "eslint-plugin-vapor",
     "version": "1.0.0",
     "description": "ESLint configuration for Vapor UI projects",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/goorm-dev/vapor-ui.git",
+        "directory": "packages/eslint-plugin-vapor"
+    },
     "license": "MIT",
     "type": "module",
     "exports": {


### PR DESCRIPTION
## Related Issues

- Linear: [VAPOR-194](https://linear.app/vaporui/issue/VAPOR-194/cirelease-npm-publish-%EC%9D%B8%EC%A6%9D%EC%9D%84-trusted-publishingoidc%EC%9C%BC%EB%A1%9C-%EB%A7%88%EC%9D%B4%EA%B7%B8%EB%A0%88%EC%9D%B4%EC%85%98)
- 실패한 run: https://github.com/goorm-dev/vapor-ui/actions/runs/29403456510

## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * npm 배포 시 신뢰할 수 있는 퍼블리싱과 provenance 검증을 지원합니다.
  * 패키지의 저장소 정보가 올바르게 표시되도록 메타데이터를 정비했습니다.
  * 핵심 패키지의 저장소 경로 정보를 정확하게 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

release job이 `E404 PUT https://registry.npmjs.org/@vapor-ui@core`로 계속 실패하고 있습니다. npm은 scoped 패키지의 인증 실패를 404로 돌려주기 때문에 패키지가 없는 게 아니라 `NPM_TOKEN`이 만료된 상황입니다. npm이 classic 토큰을 폐기하고 granular 토큰 수명을 최대 90일로 제한하면서 시크릿에 저장한 토큰은 분기마다 직접 갈아줘야 합니다.

그래서 토큰을 재발급하는 대신 [npm trusted publishing(OIDC)](https://docs.npmjs.com/trusted-publishers/)으로 전환합니다. 저장하는 시크릿이 없고 실행할 때마다 GitHub이 몇 분짜리 신원 증명을 발급합니다. provenance 증명은 덤으로 붙습니다.

| 변경                                                                         | 이유                                                                                                                                                                              |
| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `.npmrc` 주입 스텝과 `NPM_TOKEN`/`NODE_AUTH_TOKEN` env 제거                  | 토큰 env가 빈 값으로라도 남아 있으면 npm이 토큰 인증을 먼저 시도합니다. OIDC는 토큰이 아예 없어야 동작합니다                                                                      |
| release job에 `permissions: contents / pull-requests / id-token: write` 명시 | `id-token: write`가 OIDC 필수 권한입니다. permissions 블록을 명시하면 나머지 권한이 전부 꺼지므로, changesets/action이 쓰는 버전 PR 생성·태그·push 권한 두 개를 함께 선언했습니다 |
| `npm install -g npm@latest` 스텝 추가                                        | trusted publishing은 npm 11.5.1 이상을 요구합니다. `changeset publish`는 `pnpm publish`를 거쳐 결국 PATH의 npm 바이너리를 호출하므로 전역 npm 버전이 관건입니다                   |
| changesets 스텝에 `NPM_CONFIG_PROVENANCE: true`                              | 문서상 provenance는 자동이지만 누락됐다는 보고가 있어 명시했습니다                                                                                                                |
| `@vapor-ui/codemod`·`eslint-plugin-vapor`에 `repository` 필드 추가           | provenance 검증은 `repository.url`이 배포 레포와 일치해야 통과합니다. 공개 패키지 7개 중 이 둘만 빠져 있었습니다                                                                  |

공개 패키지 7개(`@vapor-ui/core`, `icons`, `hooks`, `codemod`, `color-generator`, `css-generator`, `eslint-plugin-vapor`)는 npmjs.com에 trusted publisher(`goorm-dev/vapor-ui` + `release.yml`) 등록을 마친 상태입니다.

> [!WARNING]
> npmjs 등록은 워크플로우 **파일명**에 묶입니다. `release.yml`을 리네임하면 패키지 7개의 등록도 함께 갱신해야 publish가 계속 동작합니다.


## Screenshots

<!-- N/A: CI 설정 변경이라 UI 영향 없음 -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes. <!-- N/A: CI 워크플로우 변경 — 머지 후 첫 릴리스 run이 검증입니다 -->
- [ ] I have updated the Storybook or relevant documentation. <!-- N/A: 컴포넌트·문서 표면 없음 -->
- [ ] I have added a changeset for this change. <!-- N/A: 런타임 변경 없음 — repository 필드는 다음 정기 릴리스에 메타데이터로 실려 나갑니다 -->
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
