### PR TITLE
Revert "ci(release): migrate npm publish to trusted publishing (OIDC)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ jobs:
             publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
         name: Release
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
-            id-token: write # npm trusted publishing (OIDC)
         steps:
             - name: Checkout branch
               uses: actions/checkout@v4
@@ -28,10 +24,13 @@ jobs:
             - name: Install
               uses: ./.github/composite/install
 
-            # Trusted publishing requires npm >= 11.5.1; the bundled npm depends on
-            # the resolved Node version, so pin the CLI explicitly.
-            - name: Update npm for trusted publishing
-              run: npm install -g npm@latest
+            - name: Create .npmrc file
+              run: |
+                  cat << EOF > "$HOME/.npmrc"
+                    //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+                  EOF
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets
@@ -41,8 +40,9 @@ jobs:
                   version: pnpm run version
                   commit: 'ci(changesets): version packages'
               env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_CONFIG_PROVENANCE: true
 
             - name: Update Release Notes
               if: steps.changesets.outputs.published == 'false'

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -7,11 +7,6 @@
         "jscodeshift",
         "codemod"
     ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/goorm-dev/vapor-ui.git",
-        "directory": "packages/codemod"
-    },
     "main": "dist/src/index.mjs",
     "bin": {
         "vapor-codemod": "./dist/bin/cli.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/goorm-dev/vapor-ui.git",
-        "directory": "packages/core"
+        "directory": "packages/react"
     },
     "license": "MIT",
     "author": "Vapor Team <vapor.ui@goorm.io>",

--- a/packages/eslint-plugin-vapor/package.json
+++ b/packages/eslint-plugin-vapor/package.json
@@ -2,11 +2,6 @@
     "name": "eslint-plugin-vapor",
     "version": "1.0.0",
     "description": "ESLint configuration for Vapor UI projects",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/goorm-dev/vapor-ui.git",
-        "directory": "packages/eslint-plugin-vapor"
-    },
     "license": "MIT",
     "type": "module",
     "exports": {


### PR DESCRIPTION
Reverts goorm-dev/vapor-ui#635