### PR TITLE
ci(release): migrate npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
             publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
         name: Release
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+            id-token: write # npm trusted publishing (OIDC)
         steps:
             - name: Checkout branch
               uses: actions/checkout@v4
@@ -24,13 +28,11 @@ jobs:
             - name: Install
               uses: ./.github/composite/install
 
-            - name: Create .npmrc file
-              run: |
-                  cat << EOF > "$HOME/.npmrc"
-                    //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-                  EOF
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            # Trusted publishing requires npm >= 11.5.1. Pin the version instead of
+            # @latest: npm@12 is incompatible with @changesets/cli and caused a
+            # previous release to be reverted (#636).
+            - name: Update npm for trusted publishing
+              run: npm install -g npm@11.5.1
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets
@@ -40,9 +42,8 @@ jobs:
                   version: pnpm run version
                   commit: 'ci(changesets): version packages'
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_CONFIG_PROVENANCE: true
 
             - name: Update Release Notes
               if: steps.changesets.outputs.published == 'false'

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "website": "pnpm --filter website"
     },
     "devDependencies": {
-        "@changesets/cli": "^2.31.0",
+        "@changesets/cli": "^2.31.1",
         "@changesets/get-github-info": "^0.8.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/node": "^22.19.20",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -7,6 +7,11 @@
         "jscodeshift",
         "codemod"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/goorm-dev/vapor-ui.git",
+        "directory": "packages/codemod"
+    },
     "main": "dist/src/index.mjs",
     "bin": {
         "vapor-codemod": "./dist/bin/cli.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/goorm-dev/vapor-ui.git",
-        "directory": "packages/react"
+        "directory": "packages/core"
     },
     "license": "MIT",
     "author": "Vapor Team <vapor.ui@goorm.io>",

--- a/packages/eslint-plugin-vapor/package.json
+++ b/packages/eslint-plugin-vapor/package.json
@@ -2,6 +2,11 @@
     "name": "eslint-plugin-vapor",
     "version": "1.0.0",
     "description": "ESLint configuration for Vapor UI projects",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/goorm-dev/vapor-ui.git",
+        "directory": "packages/eslint-plugin-vapor"
+    },
     "license": "MIT",
     "type": "module",
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.31.0
-        version: 2.31.0(@types/node@22.19.21)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@22.19.21)
       '@changesets/get-github-info':
         specifier: ^0.8.0
         version: 0.8.0
@@ -1655,8 +1655,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.31.0':
-    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
   '@changesets/config@3.1.4':
@@ -10889,7 +10889,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@22.19.21)':
+  '@changesets/cli@2.31.1(@types/node@22.19.21)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -10914,7 +10914,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.1
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -15093,7 +15093,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -15126,7 +15126,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15149,7 +15149,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Related Issues

#635를 다시 적용. 
#635는 npm과 `@changesets/cli`의 호환성 문제로 #636에서 revert됐는데, 이번에는 그 원인을 바로잡아 다시 올립니다.

## Description of Changes

npm trusted publishing(OIDC)을 다시 도입하되, 지난번 revert를 부른 호환성 문제를 함께 고쳤습니다.

### #635가 revert된 이유

release job이 `npm install -g npm@latest`를 실행하면서 **npm@12**가 함께 설치됐습니다. npm@12는 **`@changesets/cli@2.31.0`**과 맞지 않아 publish 단계가 실패했고, 결국 #635는 #636에서 revert됐습니다.

### 변경 내용

| 변경                                                                                                                                               | 이유                                                                                                                                                                                                                    |
| -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| npm을 `@latest` 대신 **11.5.1**로 고정                                                                                                             | trusted publishing은 npm ≥ 11.5.1을 요구한다. 버전을 고정하면 이후 실행에서 npm@12가 다시 딸려 들어오지 않는다.                                                                                                         |
| **`@changesets/cli`를 `^2.31.1`로 올림**                                                                                                           | npm 호환성 복구.                                                                                                                                                                                                        |
| `id-token: write` 권한과 `NPM_CONFIG_PROVENANCE: true` 추가                                                                                        | OIDC trusted publishing에 필요하다. `permissions` 블록을 선언하면 기본 권한이 **교체**되므로, changesets가 태그를 push하고 Version Packages PR을 여는 데 쓰는 `contents: write`·`pull-requests: write`를 다시 명시했다. |
| `@vapor-ui/core`의 `repository.directory` 수정(`packages/react` → `packages/core`), `codemod`·`eslint-plugin-vapor`에 `repository` 메타데이터 추가 | provenance 증명은 `repository`·`directory`가 실제 소스 위치와 일치해야 한다.                                                                                                                                            |
| `.npmrc` 토큰 파일과 `NPM_TOKEN` 환경변수 제거                                                                                                     | OIDC가 토큰 기반 인증을 대체한다.                                                                                                                                                                                       |

### 검증

로컬에 verdaccio 레지스트리를 띄우고 npm@11.5.1과 `@changesets/cli@2.31.1` 조합으로 publish 흐름을 재현했다. publish 단계가 더는 실패하지 않는 것을 확인했습니다.

## Screenshots

<!-- N/A: CI/설정 변경, UI 없음 -->

## Checklist

- [x] PR 제목이 Conventional Commits 규칙을 따른다.
- [ ] 변경에 대한 테스트를 추가했다. <!-- N/A: CI 워크플로우/발행 설정이라 유닛 테스트 대상이 아님. verdaccio로 로컬 검증 -->
- [ ] Storybook이나 관련 문서를 업데이트했다. <!-- N/A: 사용자 대상 컴포넌트 변경 없음 -->
- [ ] 변경에 대한 changeset을 추가했다. <!-- N/A: CI + 발행 메타데이터 변경뿐, 사용자 영향 없음 -->
- [x] self-code review를 수행했다.
- [x] 프로젝트의 코딩 컨벤션과 컴포넌트 패턴을 따랐다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포 개선**
  * npm 패키지 배포 방식을 개선해 보다 안전하고 신뢰할 수 있는 릴리즈 환경을 지원합니다.
  * 패키지 배포 시 출처 검증 정보(Provenance)가 자동으로 생성됩니다.

* **패키지 정보 개선**
  * 관련 패키지의 저장소 정보와 경로 메타데이터를 정확하게 정비했습니다.
  * 패키지 탐색 및 저장소 연결 정보가 더욱 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->