### PR TITLE
fix(css): replace `foreground-inverse` token to `basic-white`

### DIFF
--- a/packages/core/src/components/avatar/avatar.css.ts
+++ b/packages/core/src/components/avatar/avatar.css.ts
@@ -67,7 +67,7 @@ export const fallback = componentRecipe({
         width: '100%',
 
         height: '100%',
-        color: vars.color.foreground.inverse,
+        color: vars.color.white,
     },
 
     defaultVariants: { size: 'md' },

--- a/packages/core/src/components/h-stack/h-stack.stories.tsx
+++ b/packages/core/src/components/h-stack/h-stack.stories.tsx
@@ -62,7 +62,7 @@ const CustomBox = ({ size = 50, ...props }: ComponentProps<typeof Box> & { size?
                 border: '1px solid white',
                 textAlign: 'center',
                 alignContent: 'center',
-                color: '$fg-inverse',
+                color: '$basic-white',
             }}
             {...props}
         />

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -281,7 +281,7 @@ export const ToastClosePrimitive = forwardRef<HTMLButtonElement, ToastClosePrimi
         const render = renderProp ?? (
             <IconButton
                 aria-label="Close Toast"
-                $css={{ color: '$fg-inverse' }}
+                $css={{ color: '$basic-white' }}
                 colorPalette="secondary"
                 variant="ghost"
             />


### PR DESCRIPTION
## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일 개선**
  * 아바타 대체 텍스트의 색상을 흰색으로 조정해 배경과의 대비를 개선했습니다.
  * 토스트 닫기 버튼 아이콘이 흰색으로 표시되도록 변경했습니다.
  * 가로 레이아웃 예시의 텍스트 색상을 흰색으로 통일해 시각적 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- `foreground-inverse` 토큰 변경 작업 처리 시, 누락된 토큰 변경이 있었습니다.
  - Avatar.Fallback
  - Toast.Close
- 따라서 이를 모두 수정했습니다.
- 
<img width="227" height="203" alt="스크린샷 2026-08-07 오전 10 16 48" src="https://github.com/user-attachments/assets/db1c9f72-4b17-4438-8284-e93221e85ad8" />

<img width="433" height="105" alt="스크린샷 2026-08-07 오전 10 17 05" src="https://github.com/user-attachments/assets/9c99ff4b-727c-4ddf-8913-a81ce5c2cf97" />

## Screenshots

<!-- If there are any UI changes, please attach screenshots. -->
<!-- For modifications, include "Before" and "After" comparisons. -->
<!-- For new features, show the new functionality. -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
