### PR TITLE
fix(deps): use workspace:^ for internal package dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,8 +62,8 @@
         "@vanilla-extract/dynamic": "^2.1.5",
         "@vanilla-extract/recipes": "^0.5.7",
         "@vanilla-extract/sprinkles": "^1.7.0",
-        "@vapor-ui/hooks": "workspace:*",
-        "@vapor-ui/icons": "workspace:*",
+        "@vapor-ui/hooks": "workspace:^",
+        "@vapor-ui/icons": "workspace:^",
         "clsx": "^2.1.1",
         "rainbow-sprinkles": "^1.0.0"
     },

--- a/packages/css-generator/package.json
+++ b/packages/css-generator/package.json
@@ -41,7 +41,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@vapor-ui/color-generator": "workspace:*"
+        "@vapor-ui/color-generator": "workspace:^"
     },
     "devDependencies": {
         "@repo/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,10 +509,10 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(@vanilla-extract/css@1.21.2)
       '@vapor-ui/hooks':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../hooks
       '@vapor-ui/icons':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../icons
       clsx:
         specifier: ^2.1.1
@@ -624,7 +624,7 @@ importers:
   packages/css-generator:
     dependencies:
       '@vapor-ui/color-generator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../color-generator
     devDependencies:
       '@repo/eslint-config':
@@ -14590,7 +14590,7 @@ snapshots:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -14623,7 +14623,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14646,7 +14646,7 @@ snapshots:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Problem
워크스페이스 내부 패키지 의존성이 `workspace:*`로 고정되어 있었습니다. 배포된 버전에는 workspace:*가 아닌 고정된 버전으로 들어가게 됩니다.

예시 - @vapor-ui/core@1.5.0 package.json
```
 @vapor-ui/core@1.5.0 → @vapor-ui/hooks: 1.0.0-beta.6, @vapor-ui/icons: 1.2.1 (캐럿 없음)
```


이는 changeset에서 패치를 통해 릴리즈에 포함되어 있지 않은 종속 패키지도 함께 추가해서 버전이 변경되도록 설정되어 있기 때문. 

## Solution
`@vapor-ui/hooks`, `@vapor-ui/icons`, `@vapor-ui/color-generator` 의존성 명시자를 `workspace:^`로 변경해 배포 시 semver 범위가 적용되도록 했다. `pnpm-lock.yaml`도 함께 갱신했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 패키지 간 의존성 버전 범위를 호환 가능한 마이너 버전 기준으로 조정했습니다.
  * 패키지 설치 및 업데이트 시 버전 관리의 일관성과 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->