### PR TITLE
fix: correct contrast button color

### DIFF
--- a/packages/core/src/components/button/button.css.ts
+++ b/packages/core/src/components/button/button.css.ts
@@ -125,7 +125,7 @@ export const root = componentRecipe({
             },
             contrast: {
                 vars: {
-                    [variables.foreground]: vars.color.foreground.staticWhite,
+                    [variables.foreground]: vars.color.foreground.inverse,
                     [variables.outlineForeground]: vars.color.foreground['secondary'],
                     [variables.ghostForeground]: vars.color.foreground['secondary'],
                     [variables.background]: vars.color.background['contrast'],


### PR DESCRIPTION
## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 대비 색상 팔레트 버튼의 전경색을 테마에 맞는 역상 색상 토큰으로 조정했습니다.
  * 다양한 테마와 배경에서 버튼의 가독성과 시각적 일관성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Contrast 버튼의 전경색이 staticWhite로 적용되어 있어, dark 모드에서 색대비 접근성을 준수하지 못하고 있었습니다.
- figma에 맞게 색상을 `foreground-inverse`로 수정했습니다.
- TODO: 다크모드 VRT 추가

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [ ] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [ ] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
