### PR TITLE
fix(core): align surface components with canvas token hierarchy

### DIFF
--- a/.changeset/olive-jars-shake.md
+++ b/.changeset/olive-jars-shake.md
@@ -1,0 +1,5 @@
+---
+'@vapor-ui/core': minor
+---
+
+align component backgrounds with the canvas token hierarchy and expose `bg-canvas-inverse` in sprinkles

--- a/packages/core/src/components/card/card.css.ts
+++ b/packages/core/src/components/card/card.css.ts
@@ -8,7 +8,7 @@ export const root = componentStyle({
     border: `1px solid ${vars.color.border.normal}`,
     borderRadius: vars.size.borderRadius[300],
 
-    backgroundColor: vars.color.background['canvas-overlay'],
+    backgroundColor: vars.color.background['canvas-base'],
 });
 
 export const header = componentStyle({

--- a/packages/core/src/components/dialog/dialog.css.ts
+++ b/packages/core/src/components/dialog/dialog.css.ts
@@ -12,7 +12,7 @@ export const overlay = componentStyle({
     transition: 'opacity 0.15s cubic-bezier(.45,1.005,0,1.005)',
 
     opacity: 0.32,
-    backgroundColor: vars.color.black, // TODO: Use constant z-index value
+    backgroundColor: vars.color.background['canvas-dim'],
 
     selectors: {
         '&[data-starting-style], &[data-ending-style]': {

--- a/packages/core/src/components/segmented-control/segmented-control.css.ts
+++ b/packages/core/src/components/segmented-control/segmented-control.css.ts
@@ -24,7 +24,7 @@ export const root = componentRecipe({
         borderRadius: vars.size.borderRadius['300'],
 
         borderColor: vars.color.border.secondary,
-        backgroundColor: vars.color.gray['100'],
+        backgroundColor: vars.color.background['secondary'],
         padding: padding,
 
         width: 'fit-content',

--- a/packages/core/src/components/sheet/sheet.css.ts
+++ b/packages/core/src/components/sheet/sheet.css.ts
@@ -12,8 +12,9 @@ export const overlay = componentStyle({
 
     transition: 'opacity 0.15s cubic-bezier(.45,1.005,0,1.005)',
 
+    opacity: 0.32,
     backdropFilter: 'blur(1.5px)',
-    backgroundColor: 'rgba(0, 0, 0, 32%)',
+    backgroundColor: vars.color.background['canvas-dim'],
 
     selectors: {
         '&[data-starting-style], &[data-ending-style]': {

--- a/packages/core/src/styles/sprinkles.css.ts
+++ b/packages/core/src/styles/sprinkles.css.ts
@@ -219,6 +219,7 @@ const backgroundColorTokens = {
     'bg-canvas-raised': colors.background['canvas-raised'],
     'bg-canvas-dim': colors.background['canvas-dim'],
     'bg-canvas-overlay': colors.background['canvas-overlay'],
+    'bg-canvas-inverse': colors.background['canvas-inverse'],
 };
 
 const colorTokens = {

--- a/packages/core/src/styles/tokens/color/semantic-color.ts
+++ b/packages/core/src/styles/tokens/color/semantic-color.ts
@@ -183,8 +183,8 @@ export const DARK_SEMANTIC_COLORS = {
         contrast: colorRef('gray', '800'),
 
         // canvas
-        'canvas-100': canvasRef(),
-        'canvas-200': colorRef('gray', '050'),
+        'canvas-100': colorRef('gray', '050'),
+        'canvas-200': colorRef('gray', '025'),
         'overlay-100': colorRef('gray', '100'),
         'canvas-base': colorRef('gray', '050'),
         'canvas-sunken': colorRef('gray', '025'),

--- a/packages/core/src/styles/tokens/color/semantic-color.ts
+++ b/packages/core/src/styles/tokens/color/semantic-color.ts
@@ -184,7 +184,7 @@ export const DARK_SEMANTIC_COLORS = {
 
         // canvas
         'canvas-100': colorRef('gray', '050'),
-        'canvas-200': colorRef('gray', '025'),
+        'canvas-200': colorRef('gray', '100'),
         'overlay-100': colorRef('gray', '100'),
         'canvas-base': colorRef('gray', '050'),
         'canvas-sunken': colorRef('gray', '025'),


### PR DESCRIPTION
## Related Issues

- [VAPOR-255](https://linear.app/vaporui/issue/VAPOR-255)
- Related: [VAPOR-252](https://linear.app/vaporui/issue/VAPOR-252) — `canvas-inverse` 추가

## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 카드, 다이얼로그, 세그먼트 컨트롤, 시트의 배경색이 테마 캔버스 토큰과 일관되게 조정되었습니다.
  - 다이얼로그와 시트 오버레이가 테마 기반 반투명 배경과 투명도를 사용합니다.
  - 다크 테마의 캔버스 색상 단계가 개선되었습니다.

- **새 기능**
  - `bg-canvas-inverse` 배경색 유틸리티가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

`canvas-inverse`가 들어오면서 tooltip과 toast는 canvas 계열로 옮겨졌지만, 남은 표면 컴포넌트는 여전히 위계와 맞지 않는 토큰이나 raw 값을 쓰고 있었습니다. 이번 PR에서 그 나머지를 맞췄습니다.

**컴포넌트**

| 컴포넌트 | Before | After |
| --- | --- | --- |
| card | `background.canvas-overlay` | `background.canvas-base` |
| segmented-control | `color.gray.100` | `background.secondary` |
| dialog overlay | `color.black` | `background.canvas-dim` |
| sheet overlay | `rgba(0, 0, 0, 32%)` | `background.canvas-dim` + `opacity: 0.32` |

sheet 오버레이는 dialog와 같은 방식(`canvas-dim` + `opacity`)으로 통일했습니다.

**토큰**

- 다크 테마 `canvas-100`/`canvas-200`을 `gray-050`/`gray-025`로 조정했습니다. 각각 `canvas-base`/`canvas-sunken`과 값이 어긋나 있어 V1 별칭을 쓰는 쪽과 V2를 쓰는 쪽의 배경이 달라지던 문제입니다.
- sprinkles에 `bg-canvas-inverse`를 노출했습니다. VAPOR-252에서 토큰만 추가되고 sprinkles 매핑이 빠져 있었습니다.

## Screenshots

<!-- TODO: light/dark 스냅샷 첨부 -->

## Checklist

Before submitting the PR, please make sure you have checked all of the following items.

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes.
- [ ] I have updated the Storybook or relevant documentation.
- [x] I have added a changeset for this change. (e.g., for any changes that affect users, such as component prop changes or new features).
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
