### PR TITLE
ci(sync-icons): reuse a single PR instead of one per run

### DIFF
--- a/.github/workflows/sync-figma-icons.yml
+++ b/.github/workflows/sync-figma-icons.yml
@@ -7,8 +7,10 @@ on:
         - cron: '0 7 * * 4'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # Fixed group, not keyed on github.ref: every run targets the same BRANCH_NAME
+    # regardless of the ref it was dispatched from, so runs must serialize.
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
 
 env:
     BRANCH_NAME: sync-figma-icons
@@ -235,7 +237,7 @@ jobs:
                       fi
 
                       # Reuse the open PR if there is one; only its body needs refreshing
-                      EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+                      EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base main --state open --json number --jq '.[0].number // empty')
                       if [[ -n "$EXISTING_PR" ]]; then
                           gh pr edit "$EXISTING_PR" --body-file pr_body.txt
                       else
@@ -251,7 +253,7 @@ jobs:
                   else
                       # No changes means main already matches Figma, so an open PR left over
                       # from an earlier run is stale and must not be merged.
-                      STALE_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+                      STALE_PR=$(gh pr list --head "$BRANCH_NAME" --base main --state open --json number --jq '.[0].number // empty')
                       if [[ -n "$STALE_PR" ]]; then
                           gh pr close "$STALE_PR" --comment "Closing: main already matches Figma, so this sync is no longer valid."
                       fi

--- a/.github/workflows/sync-figma-icons.yml
+++ b/.github/workflows/sync-figma-icons.yml
@@ -10,6 +10,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+env:
+    BRANCH_NAME: sync-figma-icons
+
 jobs:
     sync-figma-icons:
         runs-on: ubuntu-latest
@@ -58,8 +61,7 @@ jobs:
               run: |
                   # Check if there are changes in the icons directory
                   if [[ -n $(git status --porcelain packages/icons/src/) ]]; then
-                      BRANCH_NAME="sync-figma-icons-$(date +%Y%m%d-%H%M%S)"
-                      echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+                      echo "has_changes=true" >> $GITHUB_ENV
 
                       git config --local user.email "action@github.com"
                       git config --local user.name "GitHub Action"
@@ -69,8 +71,9 @@ jobs:
                       git checkout main
                       git pull origin main
 
-                      # Create new branch from main
-                      git switch -c $BRANCH_NAME
+                      # Reset the fixed branch onto the latest main, discarding whatever it held.
+                      # Safe because the sync script rewrites every icon from Figma each run.
+                      git switch -C "$BRANCH_NAME"
 
                       # Create changeset with details about updated icons
                       CHANGESET_FILE=".changeset/sync-icons-$(date +%Y%m%d%H%M%S).md"
@@ -168,15 +171,15 @@ jobs:
                       🤖 Generated with [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
                       Co-Authored-By: GitHub Action <action@github.com>"
-                      git push -u origin $BRANCH_NAME
+                      git push --force -u origin "$BRANCH_NAME"
                   fi
 
             - name: Create Pull Request
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # Check if a branch was created (indicates changes were found)
-                  if [[ -n "${branch_name:-}" ]]; then
+                  # Check if the branch was pushed (indicates changes were found)
+                  if [[ "${has_changes:-}" == "true" ]]; then
                       # Prepare icon lists for PR body
                       NEW_BASIC_ICONS="${{ steps.sync_basic.outputs.new_icons }}"
                       NEW_SYMBOL_ICONS="${{ steps.sync_symbol.outputs.new_icons }}"
@@ -231,14 +234,27 @@ jobs:
                           echo "" >> pr_body.txt
                       fi
 
-                      gh pr create \
-                      --title "feat: sync icons from Figma" \
-                      --body-file pr_body.txt \
-                      --base main \
-                      --head "${branch_name}"
+                      # Reuse the open PR if there is one; only its body needs refreshing
+                      EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+                      if [[ -n "$EXISTING_PR" ]]; then
+                          gh pr edit "$EXISTING_PR" --body-file pr_body.txt
+                      else
+                          gh pr create \
+                          --title "feat: sync icons from Figma" \
+                          --body-file pr_body.txt \
+                          --base main \
+                          --head "$BRANCH_NAME"
+                      fi
 
                       # Clean up temporary file
                       rm -f pr_body.txt
+                  else
+                      # No changes means main already matches Figma, so an open PR left over
+                      # from an earlier run is stale and must not be merged.
+                      STALE_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+                      if [[ -n "$STALE_PR" ]]; then
+                          gh pr close "$STALE_PR" --comment "Closing: main already matches Figma, so this sync is no longer valid."
+                      fi
                   fi
 
             - name: Notify Slack on Failure


### PR DESCRIPTION
## Related Issues

<!-- N/A: 연결된 Linear 이슈 없이 진행한 CI 개선 -->

## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Figma 아이콘 동기화가 고정 브랜치를 기반으로 안정적으로 처리됩니다.
  * 변경 사항이 있을 때 기존 열린 PR을 재사용하고 내용을 갱신합니다.
  * 변경 사항이 없으면 오래된 PR이 자동으로 종료됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

아이콘 sync 워크플로우는 실행될 때마다 `sync-figma-icons-<타임스탬프>` 브랜치를 새로 만들고 PR도 새로 열었습니다. 앞선 PR이 머지되지 않으면 같은 파일을 건드리는 PR이 계속 쌓입니다. 지금 origin에는 sync 브랜치가 6개 남아 있고, #688은 일주일째 열려 있습니다.

Renovate이 의존성 하나당 PR 하나를 유지하는 방식을 가져왔습니다. 브랜치명을 `sync-figma-icons`로 고정하고, 실행할 때마다 최신 main 위에서 브랜치를 다시 만들어 force push합니다. Renovate도 rebase 대신 브랜치를 통째로 다시 만들기 때문에 커밋이 항상 하나입니다.

`sync-icons.mjs`가 Figma 전체를 매번 다시 쓰는 멱등 생성기라 이전 브랜치 내용을 읽을 필요가 없습니다. 삭제된 아이콘 처리도 마찬가지로 다시 반영됩니다.

### 동작 비교

| 상황                           | Before                        | After                             |
| ------------------------------ | ----------------------------- | --------------------------------- |
| 아이콘 변경 있음, 열린 PR 없음 | 새 브랜치 + 새 PR             | 브랜치 재생성 + PR 생성           |
| 아이콘 변경 있음, 열린 PR 있음 | 새 브랜치 + 새 PR (중복)      | 브랜치 재생성 + 기존 PR 본문 갱신 |
| 아이콘 변경 없음, 열린 PR 있음 | 아무 동작 없음 (낡은 PR 잔존) | 열린 PR close                     |

step 사이 상태는 `branch_name` 대신 `has_changes` 플래그로 넘깁니다.

### 검증

- 더미 레포에서 재생성을 확인했습니다. main이 앞서 나간 뒤에 다시 만들어도 커밋은 하나로 유지되고, main의 최신 커밋이 들어오며, 이전 라운드 내용은 남지 않았습니다.
- PR 조회 명령(`gh pr list --head <branch> --state open --json number --jq '.[0].number // empty'`)도 실제로 실행했습니다. 열린 PR이 없으면 빈 문자열, 있으면 번호가 나옵니다.
- 워크플로우 YAML 파싱과 모든 `run` 블록의 `bash -n` 문법 검사를 통과했습니다.

Figma 추출 부분(`sync-icons.mjs`, `transforms.js`)은 이번 변경에서 건드리지 않았습니다.

### 머지 후 수동 정리

- origin에 쌓인 타임스탬프 브랜치 6개 (`sync-figma-icons-20251124` ~ `sync-figma-icons-20260820`)
- #688 — `fill="#222222"`가 basic-icons에 유일한 예외로 들어가는 문제가 있어 그대로 머지하면 안 됩니다. Figma 쪽 색을 고치거나 `transforms.js`의 제거 대상에 추가하는 편이 맞습니다.

## Screenshots

<!-- N/A: UI 변경 없음 -->

## Checklist

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes. <!-- N/A: GitHub Actions 워크플로우라 단위 테스트 대상이 아님. 검증 내용은 위 "검증" 섹션 참고 -->
- [ ] I have updated the Storybook or relevant documentation. <!-- N/A: 문서 변경 없음 -->
- [ ] I have added a changeset for this change. <!-- N/A: 배포 패키지에 영향 없는 CI 변경 -->
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.
