### PR TITLE
feat(icons): connect Figma icon components via Code Connect

### DIFF
--- a/packages/icons/figma.config.json
+++ b/packages/icons/figma.config.json
@@ -1,0 +1,9 @@
+{
+    "codeConnect": {
+        "language": "typescript",
+        "include": ["src/**/*.figma.batch.json"],
+        "label": "React"
+    },
+    "fileKey": "DVgbt41m23pnHjAL8ZYsD3",
+    "packageImportPath": "@vapor-ui/icons"
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -43,6 +43,8 @@
     "scripts": {
         "build": "rimraf dist && tsup",
         "clean": "rimraf dist .turbo node_modules",
+        "figma:check": "figma connect publish --dry-run",
+        "figma:publish": "figma connect publish",
         "lint": "eslint ./src",
         "typecheck": "tsc --noEmit"
     },
@@ -50,6 +52,7 @@
         "clsx": "^2.1.1"
     },
     "devDependencies": {
+        "@figma/code-connect": "^2.0.0",
         "@repo/eslint-config": "workspace:*",
         "@repo/typescript-config": "workspace:*",
         "@types/react": "catalog:",

--- a/packages/icons/src/icon.figma.batch.ts
+++ b/packages/icons/src/icon.figma.batch.ts
@@ -1,0 +1,13 @@
+// Shared Code Connect template for every `@vapor-ui/icons` component.
+// Per-icon data (url / component / source) lives in the sibling `*.figma.batch.json`
+// files, which `sync-icons` regenerates from Figma on every sync.
+import figma from 'figma';
+
+const { component } = figma.batch as { component: string };
+
+export default {
+    example: figma.code`<${component} />`,
+    imports: [`import { ${component} } from '@vapor-ui/icons';`],
+    id: component,
+    metadata: { nestable: true },
+};

--- a/packages/icons/src/icons-basic.figma.batch.json
+++ b/packages/icons/src/icons-basic.figma.batch.json
@@ -1,0 +1,2785 @@
+{
+    "templateFile": "./icon.figma.batch.ts",
+    "components": [
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7429-373",
+            "component": "AccessibilityOutlineIcon",
+            "source": "src/components/basic-icons/AccessibilityOutlineIcon/AccessibilityOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1561-979",
+            "component": "AchievementIcon",
+            "source": "src/components/basic-icons/AchievementIcon/AchievementIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2784",
+            "component": "AchievementOutlineIcon",
+            "source": "src/components/basic-icons/AchievementOutlineIcon/AchievementOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1321",
+            "component": "AddCartOutlineIcon",
+            "source": "src/components/basic-icons/AddCartOutlineIcon/AddCartOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1512",
+            "component": "AddUserIcon",
+            "source": "src/components/basic-icons/AddUserIcon/AddUserIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1470",
+            "component": "AddUserOutlineIcon",
+            "source": "src/components/basic-icons/AddUserOutlineIcon/AddUserOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7780-466",
+            "component": "AichatOutlineIcon",
+            "source": "src/components/basic-icons/AichatOutlineIcon/AichatOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3165-124",
+            "component": "AiGoormeeIcon",
+            "source": "src/components/basic-icons/AiGoormeeIcon/AiGoormeeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2698",
+            "component": "AiGoormeeOutlineIcon",
+            "source": "src/components/basic-icons/AiGoormeeOutlineIcon/AiGoormeeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9271",
+            "component": "AirplayIcon",
+            "source": "src/components/basic-icons/AirplayIcon/AirplayIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9268",
+            "component": "AirplayOutlineIcon",
+            "source": "src/components/basic-icons/AirplayOutlineIcon/AirplayOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7102-2103",
+            "component": "AiSmartieIcon",
+            "source": "src/components/basic-icons/AiSmartieIcon/AiSmartieIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7391-383",
+            "component": "AiSmartieOutlineIcon",
+            "source": "src/components/basic-icons/AiSmartieOutlineIcon/AiSmartieOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4489-1655",
+            "component": "AlgorithmIcon",
+            "source": "src/components/basic-icons/AlgorithmIcon/AlgorithmIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-1680",
+            "component": "AlgorithmOutlineIcon",
+            "source": "src/components/basic-icons/AlgorithmOutlineIcon/AlgorithmOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1882",
+            "component": "AlignCenterOutlineIcon",
+            "source": "src/components/basic-icons/AlignCenterOutlineIcon/AlignCenterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8365-380",
+            "component": "AlignJustifyOutlineIcon",
+            "source": "src/components/basic-icons/AlignJustifyOutlineIcon/AlignJustifyOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4240",
+            "component": "AlignLeftOutlineIcon",
+            "source": "src/components/basic-icons/AlignLeftOutlineIcon/AlignLeftOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2136",
+            "component": "AlignRightOutlineIcon",
+            "source": "src/components/basic-icons/AlignRightOutlineIcon/AlignRightOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=502-502",
+            "component": "AnalysisOutlineIcon",
+            "source": "src/components/basic-icons/AnalysisOutlineIcon/AnalysisOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8007-383",
+            "component": "ArrowDownCircleIcon",
+            "source": "src/components/basic-icons/ArrowDownCircleIcon/ArrowDownCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1999",
+            "component": "ArrowDownOutlineIcon",
+            "source": "src/components/basic-icons/ArrowDownOutlineIcon/ArrowDownOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3015-83",
+            "component": "ArrowUpOutlineIcon",
+            "source": "src/components/basic-icons/ArrowUpOutlineIcon/ArrowUpOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2352-151",
+            "component": "AssignmentIcon",
+            "source": "src/components/basic-icons/AssignmentIcon/AssignmentIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2989",
+            "component": "AssignmentOutlineIcon",
+            "source": "src/components/basic-icons/AssignmentOutlineIcon/AssignmentOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7286-725",
+            "component": "AttachFileOutlineIcon",
+            "source": "src/components/basic-icons/AttachFileOutlineIcon/AttachFileOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4517-7",
+            "component": "AttemptOutlineIcon",
+            "source": "src/components/basic-icons/AttemptOutlineIcon/AttemptOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2308",
+            "component": "AutoCodeOutlineIcon",
+            "source": "src/components/basic-icons/AutoCodeOutlineIcon/AutoCodeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1411",
+            "component": "BackPageOutlineIcon",
+            "source": "src/components/basic-icons/BackPageOutlineIcon/BackPageOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2724",
+            "component": "BackUpOutlineIcon",
+            "source": "src/components/basic-icons/BackUpOutlineIcon/BackUpOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-1010",
+            "component": "BedIcon",
+            "source": "src/components/basic-icons/BedIcon/BedIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2288",
+            "component": "BedOutlineIcon",
+            "source": "src/components/basic-icons/BedOutlineIcon/BedOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1365",
+            "component": "BellOffIcon",
+            "source": "src/components/basic-icons/BellOffIcon/BellOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1394",
+            "component": "BellOffOutlineIcon",
+            "source": "src/components/basic-icons/BellOffOutlineIcon/BellOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6681-1338",
+            "component": "BellOnIcon",
+            "source": "src/components/basic-icons/BellOnIcon/BellOnIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1354",
+            "component": "BellOnOutlineIcon",
+            "source": "src/components/basic-icons/BellOnOutlineIcon/BellOnOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4997-11",
+            "component": "BlankOutlineIcon",
+            "source": "src/components/basic-icons/BlankOutlineIcon/BlankOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=713-458",
+            "component": "BlockOutlineIcon",
+            "source": "src/components/basic-icons/BlockOutlineIcon/BlockOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2146",
+            "component": "BoldOutlineIcon",
+            "source": "src/components/basic-icons/BoldOutlineIcon/BoldOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=106-11",
+            "component": "BookIcon",
+            "source": "src/components/basic-icons/BookIcon/BookIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6681-1320",
+            "component": "BookmarkIcon",
+            "source": "src/components/basic-icons/BookmarkIcon/BookmarkIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6681-1327",
+            "component": "BookmarkOutlineIcon",
+            "source": "src/components/basic-icons/BookmarkOutlineIcon/BookmarkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2889",
+            "component": "BookOutlineIcon",
+            "source": "src/components/basic-icons/BookOutlineIcon/BookOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4253",
+            "component": "BottomPlayerIcon",
+            "source": "src/components/basic-icons/BottomPlayerIcon/BottomPlayerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1303",
+            "component": "BottomPlayerOutlineIcon",
+            "source": "src/components/basic-icons/BottomPlayerOutlineIcon/BottomPlayerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4182",
+            "component": "BranchIcon",
+            "source": "src/components/basic-icons/BranchIcon/BranchIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1315",
+            "component": "BranchOutlineIcon",
+            "source": "src/components/basic-icons/BranchOutlineIcon/BranchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2399",
+            "component": "BreakpointIcon",
+            "source": "src/components/basic-icons/BreakpointIcon/BreakpointIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4193",
+            "component": "BuildIcon",
+            "source": "src/components/basic-icons/BuildIcon/BuildIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1301",
+            "component": "BuildOutlineIcon",
+            "source": "src/components/basic-icons/BuildOutlineIcon/BuildOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7378-725",
+            "component": "BulletlistOutlineIcon",
+            "source": "src/components/basic-icons/BulletlistOutlineIcon/BulletlistOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-1008",
+            "component": "CafeIcon",
+            "source": "src/components/basic-icons/CafeIcon/CafeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2285",
+            "component": "CafeOutlineIcon",
+            "source": "src/components/basic-icons/CafeOutlineIcon/CafeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-977",
+            "component": "CakeIcon",
+            "source": "src/components/basic-icons/CakeIcon/CakeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2289",
+            "component": "CakeOutlineIcon",
+            "source": "src/components/basic-icons/CakeOutlineIcon/CakeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3930-76",
+            "component": "CalculatorIcon",
+            "source": "src/components/basic-icons/CalculatorIcon/CalculatorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1316",
+            "component": "CalculatorOutlineIcon",
+            "source": "src/components/basic-icons/CalculatorOutlineIcon/CalculatorOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4241",
+            "component": "CalendarIcon",
+            "source": "src/components/basic-icons/CalendarIcon/CalendarIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1434",
+            "component": "CalendarOutlineIcon",
+            "source": "src/components/basic-icons/CalendarOutlineIcon/CalendarOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7014-2264",
+            "component": "CallIcon",
+            "source": "src/components/basic-icons/CallIcon/CallIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7014-2263",
+            "component": "CallOutlineIcon",
+            "source": "src/components/basic-icons/CallOutlineIcon/CallOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6638-391",
+            "component": "CameraIcon",
+            "source": "src/components/basic-icons/CameraIcon/CameraIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6638-390",
+            "component": "CameraOutlineIcon",
+            "source": "src/components/basic-icons/CameraOutlineIcon/CameraOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9336",
+            "component": "CampIcon",
+            "source": "src/components/basic-icons/CampIcon/CampIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9330",
+            "component": "CampOutlineIcon",
+            "source": "src/components/basic-icons/CampOutlineIcon/CampOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4273",
+            "component": "CaptionIcon",
+            "source": "src/components/basic-icons/CaptionIcon/CaptionIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-2132",
+            "component": "CaptionOutlineIcon",
+            "source": "src/components/basic-icons/CaptionOutlineIcon/CaptionOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4275",
+            "component": "CardsIcon",
+            "source": "src/components/basic-icons/CardsIcon/CardsIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=60-60",
+            "component": "CardsOutlineIcon",
+            "source": "src/components/basic-icons/CardsOutlineIcon/CardsOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1525",
+            "component": "CaretDownIcon",
+            "source": "src/components/basic-icons/CaretDownIcon/CaretDownIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1527",
+            "component": "CaretLeftIcon",
+            "source": "src/components/basic-icons/CaretLeftIcon/CaretLeftIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1528",
+            "component": "CaretRightIcon",
+            "source": "src/components/basic-icons/CaretRightIcon/CaretRightIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1526",
+            "component": "CaretUpIcon",
+            "source": "src/components/basic-icons/CaretUpIcon/CaretUpIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-986",
+            "component": "CarIcon",
+            "source": "src/components/basic-icons/CarIcon/CarIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2286",
+            "component": "CarOutlineIcon",
+            "source": "src/components/basic-icons/CarOutlineIcon/CarOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1303",
+            "component": "CertificateIcon",
+            "source": "src/components/basic-icons/CertificateIcon/CertificateIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1306",
+            "component": "CertificateOutlineIcon",
+            "source": "src/components/basic-icons/CertificateOutlineIcon/CertificateOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1312",
+            "component": "ChapterIcon",
+            "source": "src/components/basic-icons/ChapterIcon/ChapterIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1309",
+            "component": "ChapterOutlineIcon",
+            "source": "src/components/basic-icons/ChapterOutlineIcon/ChapterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=502-504",
+            "component": "ChartOutlineIcon",
+            "source": "src/components/basic-icons/ChartOutlineIcon/ChartOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1902",
+            "component": "ChartPieIcon",
+            "source": "src/components/basic-icons/ChartPieIcon/ChartPieIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1430",
+            "component": "ChartPieOutlineIcon",
+            "source": "src/components/basic-icons/ChartPieOutlineIcon/ChartPieOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8007-386",
+            "component": "CheckboxIcon",
+            "source": "src/components/basic-icons/CheckboxIcon/CheckboxIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9223",
+            "component": "CheckCartOutlineIcon",
+            "source": "src/components/basic-icons/CheckCartOutlineIcon/CheckCartOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1349",
+            "component": "CheckCircleIcon",
+            "source": "src/components/basic-icons/CheckCircleIcon/CheckCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1392",
+            "component": "CheckCircleOutlineIcon",
+            "source": "src/components/basic-icons/CheckCircleOutlineIcon/CheckCircleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9120-376",
+            "component": "ChecklistOutlineIcon",
+            "source": "src/components/basic-icons/ChecklistOutlineIcon/ChecklistOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1570",
+            "component": "ChevronDoubleLeftOutlineIcon",
+            "source": "src/components/basic-icons/ChevronDoubleLeftOutlineIcon/ChevronDoubleLeftOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1578",
+            "component": "ChevronDoubleRightOutlineIcon",
+            "source": "src/components/basic-icons/ChevronDoubleRightOutlineIcon/ChevronDoubleRightOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1305",
+            "component": "ChevronDownOutlineIcon",
+            "source": "src/components/basic-icons/ChevronDownOutlineIcon/ChevronDownOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1319",
+            "component": "ChevronLeftOutlineIcon",
+            "source": "src/components/basic-icons/ChevronLeftOutlineIcon/ChevronLeftOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1325",
+            "component": "ChevronRightOutlineIcon",
+            "source": "src/components/basic-icons/ChevronRightOutlineIcon/ChevronRightOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1314",
+            "component": "ChevronUpOutlineIcon",
+            "source": "src/components/basic-icons/ChevronUpOutlineIcon/ChevronUpOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2203",
+            "component": "ClassIcon",
+            "source": "src/components/basic-icons/ClassIcon/ClassIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1424",
+            "component": "CloseOutlineIcon",
+            "source": "src/components/basic-icons/CloseOutlineIcon/CloseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-3532",
+            "component": "CodeBlockIcon",
+            "source": "src/components/basic-icons/CodeBlockIcon/CodeBlockIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=5197-554",
+            "component": "CodeBlockOutlineIcon",
+            "source": "src/components/basic-icons/CodeBlockOutlineIcon/CodeBlockOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=830-453",
+            "component": "CodevisorIcon",
+            "source": "src/components/basic-icons/CodevisorIcon/CodevisorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4207",
+            "component": "CollaborationIcon",
+            "source": "src/components/basic-icons/CollaborationIcon/CollaborationIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2591",
+            "component": "CollaborationOutlineIcon",
+            "source": "src/components/basic-icons/CollaborationOutlineIcon/CollaborationOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4716-6",
+            "component": "CollapseOutlineIcon",
+            "source": "src/components/basic-icons/CollapseOutlineIcon/CollapseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1646",
+            "component": "CommitOutlineIcon",
+            "source": "src/components/basic-icons/CommitOutlineIcon/CommitOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8148-384",
+            "component": "ComponentIcon",
+            "source": "src/components/basic-icons/ComponentIcon/ComponentIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1421",
+            "component": "ConfirmOutlineIcon",
+            "source": "src/components/basic-icons/ConfirmOutlineIcon/ConfirmOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4211",
+            "component": "ContainerIcon",
+            "source": "src/components/basic-icons/ContainerIcon/ContainerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1290",
+            "component": "ContainerOutlineIcon",
+            "source": "src/components/basic-icons/ContainerOutlineIcon/ContainerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3368-89",
+            "component": "ContainerRunIcon",
+            "source": "src/components/basic-icons/ContainerRunIcon/ContainerRunIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1288",
+            "component": "ContainerRunOutlineIcon",
+            "source": "src/components/basic-icons/ContainerRunOutlineIcon/ContainerRunOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2347",
+            "component": "ContainerShareIcon",
+            "source": "src/components/basic-icons/ContainerShareIcon/ContainerShareIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1291",
+            "component": "ContainerShareOutlineIcon",
+            "source": "src/components/basic-icons/ContainerShareOutlineIcon/ContainerShareOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7718-394",
+            "component": "ContainerStopIcon",
+            "source": "src/components/basic-icons/ContainerStopIcon/ContainerStopIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7718-409",
+            "component": "ContainerStopOutlineIcon",
+            "source": "src/components/basic-icons/ContainerStopOutlineIcon/ContainerStopOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4210",
+            "component": "ContainerToImageIcon",
+            "source": "src/components/basic-icons/ContainerToImageIcon/ContainerToImageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-558",
+            "component": "ControlCommonIcon",
+            "source": "src/components/basic-icons/ControlCommonIcon/ControlCommonIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1400",
+            "component": "ControlCommonOutlineIcon",
+            "source": "src/components/basic-icons/ControlCommonOutlineIcon/ControlCommonOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8469-375",
+            "component": "CopyAsMarkdownOutlineIcon",
+            "source": "src/components/basic-icons/CopyAsMarkdownOutlineIcon/CopyAsMarkdownOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4154",
+            "component": "CopyIcon",
+            "source": "src/components/basic-icons/CopyIcon/CopyIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1443",
+            "component": "CopyOutlineIcon",
+            "source": "src/components/basic-icons/CopyOutlineIcon/CopyOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2124",
+            "component": "CorrectOutlineIcon",
+            "source": "src/components/basic-icons/CorrectOutlineIcon/CorrectOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4256",
+            "component": "CouponIcon",
+            "source": "src/components/basic-icons/CouponIcon/CouponIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1403",
+            "component": "CouponOutlineIcon",
+            "source": "src/components/basic-icons/CouponOutlineIcon/CouponOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4243",
+            "component": "CourseHistoryIcon",
+            "source": "src/components/basic-icons/CourseHistoryIcon/CourseHistoryIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9262",
+            "component": "CourseIcon",
+            "source": "src/components/basic-icons/CourseIcon/CourseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9265",
+            "component": "CourseOutlineIcon",
+            "source": "src/components/basic-icons/CourseOutlineIcon/CourseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4180",
+            "component": "CpuIcon",
+            "source": "src/components/basic-icons/CpuIcon/CpuIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1292",
+            "component": "CpuOutlineIcon",
+            "source": "src/components/basic-icons/CpuOutlineIcon/CpuOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2401",
+            "component": "CreateBranchOutlineIcon",
+            "source": "src/components/basic-icons/CreateBranchOutlineIcon/CreateBranchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4209",
+            "component": "CreditCardIcon",
+            "source": "src/components/basic-icons/CreditCardIcon/CreditCardIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1627",
+            "component": "CreditCardOutlineIcon",
+            "source": "src/components/basic-icons/CreditCardOutlineIcon/CreditCardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1060-1260",
+            "component": "CursorshareoffIcon",
+            "source": "src/components/basic-icons/CursorshareoffIcon/CursorshareoffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1060-1261",
+            "component": "CursorshareonIcon",
+            "source": "src/components/basic-icons/CursorshareonIcon/CursorshareonIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2036-983",
+            "component": "DarkIcon",
+            "source": "src/components/basic-icons/DarkIcon/DarkIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1597",
+            "component": "DarkOutlineIcon",
+            "source": "src/components/basic-icons/DarkOutlineIcon/DarkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7102-2121",
+            "component": "DashboardIcon",
+            "source": "src/components/basic-icons/DashboardIcon/DashboardIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7391-384",
+            "component": "DashboardOutlineIcon",
+            "source": "src/components/basic-icons/DashboardOutlineIcon/DashboardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4489-1656",
+            "component": "DatabaseIcon",
+            "source": "src/components/basic-icons/DatabaseIcon/DatabaseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-1675",
+            "component": "DatabaseOutlineIcon",
+            "source": "src/components/basic-icons/DatabaseOutlineIcon/DatabaseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2418",
+            "component": "DebugContinueIcon",
+            "source": "src/components/basic-icons/DebugContinueIcon/DebugContinueIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2288",
+            "component": "DebugIcon",
+            "source": "src/components/basic-icons/DebugIcon/DebugIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1293",
+            "component": "DebugOutlineIcon",
+            "source": "src/components/basic-icons/DebugOutlineIcon/DebugOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1060-1269",
+            "component": "DeployOutlineIcon",
+            "source": "src/components/basic-icons/DeployOutlineIcon/DeployOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3375-79",
+            "component": "DeployPushIcon",
+            "source": "src/components/basic-icons/DeployPushIcon/DeployPushIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1297",
+            "component": "DeployPushOutlineIcon",
+            "source": "src/components/basic-icons/DeployPushOutlineIcon/DeployPushOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4202",
+            "component": "DetailViewIcon",
+            "source": "src/components/basic-icons/DetailViewIcon/DetailViewIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1472",
+            "component": "DetailViewOutlineIcon",
+            "source": "src/components/basic-icons/DetailViewOutlineIcon/DetailViewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=10057-460",
+            "component": "DevicesIcon",
+            "source": "src/components/basic-icons/DevicesIcon/DevicesIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=765-431",
+            "component": "DiscardOutlineIcon",
+            "source": "src/components/basic-icons/DiscardOutlineIcon/DiscardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2519",
+            "component": "DiscIcon",
+            "source": "src/components/basic-icons/DiscIcon/DiscIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2981",
+            "component": "DiscOutlineIcon",
+            "source": "src/components/basic-icons/DiscOutlineIcon/DiscOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4489-1636",
+            "component": "DiscussionIcon",
+            "source": "src/components/basic-icons/DiscussionIcon/DiscussionIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1445",
+            "component": "DiscussionOutlineIcon",
+            "source": "src/components/basic-icons/DiscussionOutlineIcon/DiscussionOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2390",
+            "component": "DiskIcon",
+            "source": "src/components/basic-icons/DiskIcon/DiskIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4233",
+            "component": "DislikeIcon",
+            "source": "src/components/basic-icons/DislikeIcon/DislikeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1654",
+            "component": "DislikeOutlineIcon",
+            "source": "src/components/basic-icons/DislikeOutlineIcon/DislikeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1346",
+            "component": "DislikeThumbIcon",
+            "source": "src/components/basic-icons/DislikeThumbIcon/DislikeThumbIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1389",
+            "component": "DislikeThumbOutlineIcon",
+            "source": "src/components/basic-icons/DislikeThumbOutlineIcon/DislikeThumbOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4668-4",
+            "component": "DividerIcon",
+            "source": "src/components/basic-icons/DividerIcon/DividerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1307",
+            "component": "DividerOutlineIcon",
+            "source": "src/components/basic-icons/DividerOutlineIcon/DividerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8769-407",
+            "component": "DocktoBottomIcon",
+            "source": "src/components/basic-icons/DocktoBottomIcon/DocktoBottomIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8769-406",
+            "component": "DocktoBottomOutlineIcon",
+            "source": "src/components/basic-icons/DocktoBottomOutlineIcon/DocktoBottomOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7057-2264",
+            "component": "DocumentViewerIcon",
+            "source": "src/components/basic-icons/DocumentViewerIcon/DocumentViewerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7057-2295",
+            "component": "DocumentViewerOutlineIcon",
+            "source": "src/components/basic-icons/DocumentViewerOutlineIcon/DocumentViewerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2108-1101",
+            "component": "DollarOutlineIcon",
+            "source": "src/components/basic-icons/DollarOutlineIcon/DollarOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4229-96",
+            "component": "DotIcon",
+            "source": "src/components/basic-icons/DotIcon/DotIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1340",
+            "component": "DownloadIcon",
+            "source": "src/components/basic-icons/DownloadIcon/DownloadIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1381",
+            "component": "DownloadOutlineIcon",
+            "source": "src/components/basic-icons/DownloadOutlineIcon/DownloadOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2530",
+            "component": "DragIndicatorIcon",
+            "source": "src/components/basic-icons/DragIndicatorIcon/DragIndicatorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4224",
+            "component": "EditIcon",
+            "source": "src/components/basic-icons/EditIcon/EditIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1492",
+            "component": "EditOutlineIcon",
+            "source": "src/components/basic-icons/EditOutlineIcon/EditOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4997-12",
+            "component": "EnterOutlineIcon",
+            "source": "src/components/basic-icons/EnterOutlineIcon/EnterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4242",
+            "component": "EqualOutlineIcon",
+            "source": "src/components/basic-icons/EqualOutlineIcon/EqualOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-1847",
+            "component": "EraserIcon",
+            "source": "src/components/basic-icons/EraserIcon/EraserIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1914",
+            "component": "EraserOutlineIcon",
+            "source": "src/components/basic-icons/EraserOutlineIcon/EraserOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1352",
+            "component": "ErrorCircleIcon",
+            "source": "src/components/basic-icons/ErrorCircleIcon/ErrorCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1395",
+            "component": "ErrorCircleOutlineIcon",
+            "source": "src/components/basic-icons/ErrorCircleOutlineIcon/ErrorCircleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4246",
+            "component": "ExamIcon",
+            "source": "src/components/basic-icons/ExamIcon/ExamIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1922",
+            "component": "ExamListIcon",
+            "source": "src/components/basic-icons/ExamListIcon/ExamListIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2796",
+            "component": "ExamListOutlineIcon",
+            "source": "src/components/basic-icons/ExamListOutlineIcon/ExamListOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2561",
+            "component": "ExamOutlineIcon",
+            "source": "src/components/basic-icons/ExamOutlineIcon/ExamOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1935",
+            "component": "ExamReportIcon",
+            "source": "src/components/basic-icons/ExamReportIcon/ExamReportIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2663",
+            "component": "ExamReportOutlineIcon",
+            "source": "src/components/basic-icons/ExamReportOutlineIcon/ExamReportOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4717-40",
+            "component": "ExpandOutlineIcon",
+            "source": "src/components/basic-icons/ExpandOutlineIcon/ExpandOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2229",
+            "component": "ExploreIcon",
+            "source": "src/components/basic-icons/ExploreIcon/ExploreIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2284",
+            "component": "ExploreOutlineIcon",
+            "source": "src/components/basic-icons/ExploreOutlineIcon/ExploreOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1624",
+            "component": "ExportIcon",
+            "source": "src/components/basic-icons/ExportIcon/ExportIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-566",
+            "component": "ExportImageIcon",
+            "source": "src/components/basic-icons/ExportImageIcon/ExportImageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1628",
+            "component": "ExportOutlineIcon",
+            "source": "src/components/basic-icons/ExportOutlineIcon/ExportOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=837-434",
+            "component": "FileAddIcon",
+            "source": "src/components/basic-icons/FileAddIcon/FileAddIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-2147",
+            "component": "FileAddOutlineIcon",
+            "source": "src/components/basic-icons/FileAddOutlineIcon/FileAddOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=837-436",
+            "component": "FileDeleteIcon",
+            "source": "src/components/basic-icons/FileDeleteIcon/FileDeleteIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-2154",
+            "component": "FileDeleteOutlineIcon",
+            "source": "src/components/basic-icons/FileDeleteOutlineIcon/FileDeleteOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4221",
+            "component": "FileEditOutlineIcon",
+            "source": "src/components/basic-icons/FileEditOutlineIcon/FileEditOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4218",
+            "component": "FileIcon",
+            "source": "src/components/basic-icons/FileIcon/FileIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1084-560",
+            "component": "FilenewIcon",
+            "source": "src/components/basic-icons/FilenewIcon/FilenewIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1469",
+            "component": "FileNewOutlineIcon",
+            "source": "src/components/basic-icons/FileNewOutlineIcon/FileNewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1626",
+            "component": "FileOutlineIcon",
+            "source": "src/components/basic-icons/FileOutlineIcon/FileOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1449",
+            "component": "FilterIcon",
+            "source": "src/components/basic-icons/FilterIcon/FilterIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1438",
+            "component": "FilterOutlineIcon",
+            "source": "src/components/basic-icons/FilterOutlineIcon/FilterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2104",
+            "component": "FlagIcon",
+            "source": "src/components/basic-icons/FlagIcon/FlagIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-3012",
+            "component": "FlagOutlineIcon",
+            "source": "src/components/basic-icons/FlagOutlineIcon/FlagOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4181",
+            "component": "FlaskIcon",
+            "source": "src/components/basic-icons/FlaskIcon/FlaskIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1305",
+            "component": "FlaskIIconcon",
+            "source": "src/components/basic-icons/FlaskIIconcon/FlaskIIconcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9247",
+            "component": "FlightIcon",
+            "source": "src/components/basic-icons/FlightIcon/FlightIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2436",
+            "component": "FolderIcon",
+            "source": "src/components/basic-icons/FolderIcon/FolderIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1084-563",
+            "component": "FolderNewIcon",
+            "source": "src/components/basic-icons/FolderNewIcon/FolderNewIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1309",
+            "component": "FolderNewOutlineIcon",
+            "source": "src/components/basic-icons/FolderNewOutlineIcon/FolderNewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1299",
+            "component": "FolderOutlineIcon",
+            "source": "src/components/basic-icons/FolderOutlineIcon/FolderOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2172",
+            "component": "FolderSearchIcon",
+            "source": "src/components/basic-icons/FolderSearchIcon/FolderSearchIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1312",
+            "component": "FolderSearchOutlineIcon",
+            "source": "src/components/basic-icons/FolderSearchOutlineIcon/FolderSearchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4753-4",
+            "component": "FoldIcon",
+            "source": "src/components/basic-icons/FoldIcon/FoldIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1295",
+            "component": "FoldOutlineIcon",
+            "source": "src/components/basic-icons/FoldOutlineIcon/FoldOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1803-976",
+            "component": "ForkIcon",
+            "source": "src/components/basic-icons/ForkIcon/ForkIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1313",
+            "component": "ForkOutlineIcon",
+            "source": "src/components/basic-icons/ForkOutlineIcon/ForkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4791-10",
+            "component": "FormatColorTextOutlineIcon",
+            "source": "src/components/basic-icons/FormatColorTextOutlineIcon/FormatColorTextOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1417",
+            "component": "ForwardPageOutlineIcon",
+            "source": "src/components/basic-icons/ForwardPageOutlineIcon/ForwardPageOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4194",
+            "component": "FunctionIcon",
+            "source": "src/components/basic-icons/FunctionIcon/FunctionIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1310",
+            "component": "FunctionOutlineIcon",
+            "source": "src/components/basic-icons/FunctionOutlineIcon/FunctionOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4248",
+            "component": "FunctionsOutlineIcon",
+            "source": "src/components/basic-icons/FunctionsOutlineIcon/FunctionsOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-1009",
+            "component": "GameIcon",
+            "source": "src/components/basic-icons/GameIcon/GameIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2994",
+            "component": "GameOutlineIcon",
+            "source": "src/components/basic-icons/GameOutlineIcon/GameOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2692-88",
+            "component": "GiftOutlineIcon",
+            "source": "src/components/basic-icons/GiftOutlineIcon/GiftOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-570",
+            "component": "GitIcon",
+            "source": "src/components/basic-icons/GitIcon/GitIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2422",
+            "component": "GitMergeOutlineIcon",
+            "source": "src/components/basic-icons/GitMergeOutlineIcon/GitMergeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4255",
+            "component": "GlobalOutlineIcon",
+            "source": "src/components/basic-icons/GlobalOutlineIcon/GlobalOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1983",
+            "component": "GoogleDrawingIcon",
+            "source": "src/components/basic-icons/GoogleDrawingIcon/GoogleDrawingIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1470",
+            "component": "GoogleDrawingOutlineIcon",
+            "source": "src/components/basic-icons/GoogleDrawingOutlineIcon/GoogleDrawingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2006",
+            "component": "GooglePresentationIcon",
+            "source": "src/components/basic-icons/GooglePresentationIcon/GooglePresentationIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1467",
+            "component": "GooglePresentationOutlineIcon",
+            "source": "src/components/basic-icons/GooglePresentationOutlineIcon/GooglePresentationOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4266",
+            "component": "GoogleSpreadsheetIcon",
+            "source": "src/components/basic-icons/GoogleSpreadsheetIcon/GoogleSpreadsheetIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1468",
+            "component": "GoogleSpreadsheetOutlineIcon",
+            "source": "src/components/basic-icons/GoogleSpreadsheetOutlineIcon/GoogleSpreadsheetOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1908",
+            "component": "GoormduinoIcon",
+            "source": "src/components/basic-icons/GoormduinoIcon/GoormduinoIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4548-8",
+            "component": "GpuIcon",
+            "source": "src/components/basic-icons/GpuIcon/GpuIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1518",
+            "component": "GroupIcon",
+            "source": "src/components/basic-icons/GroupIcon/GroupIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1478",
+            "component": "GroupOutlineIcon",
+            "source": "src/components/basic-icons/GroupOutlineIcon/GroupOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4212",
+            "component": "GuestIcon",
+            "source": "src/components/basic-icons/GuestIcon/GuestIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7251-765",
+            "component": "HardBreakOutlineIcon",
+            "source": "src/components/basic-icons/HardBreakOutlineIcon/HardBreakOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9120-382",
+            "component": "Heading1OutlineIcon",
+            "source": "src/components/basic-icons/Heading1OutlineIcon/Heading1OutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9120-380",
+            "component": "Heading2OutlineIcon",
+            "source": "src/components/basic-icons/Heading2OutlineIcon/Heading2OutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9120-378",
+            "component": "Heading3OutlineIcon",
+            "source": "src/components/basic-icons/Heading3OutlineIcon/Heading3OutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9124-391",
+            "component": "Heading4OutlineIcon",
+            "source": "src/components/basic-icons/Heading4OutlineIcon/Heading4OutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6675-1301",
+            "component": "HeartIcon",
+            "source": "src/components/basic-icons/HeartIcon/HeartIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1395",
+            "component": "HeartOutlineIcon",
+            "source": "src/components/basic-icons/HeartOutlineIcon/HeartOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1355",
+            "component": "HelpCircleIcon",
+            "source": "src/components/basic-icons/HelpCircleIcon/HelpCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1398",
+            "component": "HelpCircleOutlineIcon",
+            "source": "src/components/basic-icons/HelpCircleOutlineIcon/HelpCircleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2131",
+            "component": "HelpIcon",
+            "source": "src/components/basic-icons/HelpIcon/HelpIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9235",
+            "component": "HighlightViewIcon",
+            "source": "src/components/basic-icons/HighlightViewIcon/HighlightViewIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9232",
+            "component": "HighlightViewOutlineIcon",
+            "source": "src/components/basic-icons/HighlightViewOutlineIcon/HighlightViewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2165",
+            "component": "HistoryOutlineIcon",
+            "source": "src/components/basic-icons/HistoryOutlineIcon/HistoryOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1503",
+            "component": "HomeIcon",
+            "source": "src/components/basic-icons/HomeIcon/HomeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1461",
+            "component": "HomeOutlineIcon",
+            "source": "src/components/basic-icons/HomeOutlineIcon/HomeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=538-488",
+            "component": "HourglassIcon",
+            "source": "src/components/basic-icons/HourglassIcon/HourglassIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-585",
+            "component": "IdCardIcon",
+            "source": "src/components/basic-icons/IdCardIcon/IdCardIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2583",
+            "component": "IdCardOutlineIcon",
+            "source": "src/components/basic-icons/IdCardOutlineIcon/IdCardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2019",
+            "component": "IdeShareIcon",
+            "source": "src/components/basic-icons/IdeShareIcon/IdeShareIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=10057-447",
+            "component": "IdIcon",
+            "source": "src/components/basic-icons/IdIcon/IdIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1990",
+            "component": "ImageIcon",
+            "source": "src/components/basic-icons/ImageIcon/ImageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1564",
+            "component": "ImageOutlineIcon",
+            "source": "src/components/basic-icons/ImageOutlineIcon/ImageOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1798-991",
+            "component": "ImagePackIcon",
+            "source": "src/components/basic-icons/ImagePackIcon/ImagePackIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2860",
+            "component": "ImagePackOutlineIcon",
+            "source": "src/components/basic-icons/ImagePackOutlineIcon/ImagePackOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2523",
+            "component": "ImageToContainerIcon",
+            "source": "src/components/basic-icons/ImageToContainerIcon/ImageToContainerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1289",
+            "component": "ImageToContainerOutlineIcon",
+            "source": "src/components/basic-icons/ImageToContainerOutlineIcon/ImageToContainerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1631",
+            "component": "ImportIcon",
+            "source": "src/components/basic-icons/ImportIcon/ImportIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1638",
+            "component": "ImportOutlineIcon",
+            "source": "src/components/basic-icons/ImportOutlineIcon/ImportOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8365-381",
+            "component": "IndentDecreaseOutlineIcon",
+            "source": "src/components/basic-icons/IndentDecreaseOutlineIcon/IndentDecreaseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2360",
+            "component": "IndentIncreaseOutlineIcon",
+            "source": "src/components/basic-icons/IndentIncreaseOutlineIcon/IndentIncreaseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-601",
+            "component": "InfiniteOutlineIcon",
+            "source": "src/components/basic-icons/InfiniteOutlineIcon/InfiniteOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1361",
+            "component": "InfoCircleIcon",
+            "source": "src/components/basic-icons/InfoCircleIcon/InfoCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1406",
+            "component": "InfoCircleOutlineIcon",
+            "source": "src/components/basic-icons/InfoCircleOutlineIcon/InfoCircleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1455",
+            "component": "InOutlineIcon",
+            "source": "src/components/basic-icons/InOutlineIcon/InOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4183",
+            "component": "InputSettingOutlineIcon",
+            "source": "src/components/basic-icons/InputSettingOutlineIcon/InputSettingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4198",
+            "component": "IntelliSenseClassIcon",
+            "source": "src/components/basic-icons/IntelliSenseClassIcon/IntelliSenseClassIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2492",
+            "component": "IntelliSenseColorIcon",
+            "source": "src/components/basic-icons/IntelliSenseColorIcon/IntelliSenseColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4158",
+            "component": "IntelliSenseConstantIcon",
+            "source": "src/components/basic-icons/IntelliSenseConstantIcon/IntelliSenseConstantIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2483",
+            "component": "IntelliSenseEnumIcon",
+            "source": "src/components/basic-icons/IntelliSenseEnumIcon/IntelliSenseEnumIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1311",
+            "component": "IntelliSenseEnumOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseEnumOutlineIcon/IntelliSenseEnumOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4157",
+            "component": "IntelliSenseEventIcon",
+            "source": "src/components/basic-icons/IntelliSenseEventIcon/IntelliSenseEventIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2632",
+            "component": "IntelliSenseEventOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseEventOutlineIcon/IntelliSenseEventOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4200",
+            "component": "IntelliSenseFieldOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseFieldOutlineIcon/IntelliSenseFieldOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4201",
+            "component": "IntelliSenseFunctionIcon",
+            "source": "src/components/basic-icons/IntelliSenseFunctionIcon/IntelliSenseFunctionIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4161",
+            "component": "IntelliSenseInterfaceIcon",
+            "source": "src/components/basic-icons/IntelliSenseInterfaceIcon/IntelliSenseInterfaceIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4165",
+            "component": "IntelliSenseModuleIcon",
+            "source": "src/components/basic-icons/IntelliSenseModuleIcon/IntelliSenseModuleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1306",
+            "component": "IntelliSenseModuleOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseModuleOutlineIcon/IntelliSenseModuleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4163",
+            "component": "IntelliSenseNullIcon",
+            "source": "src/components/basic-icons/IntelliSenseNullIcon/IntelliSenseNullIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2506",
+            "component": "IntelliSenseOperatorIcon",
+            "source": "src/components/basic-icons/IntelliSenseOperatorIcon/IntelliSenseOperatorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2855",
+            "component": "IntelliSensePropertyIcon",
+            "source": "src/components/basic-icons/IntelliSensePropertyIcon/IntelliSensePropertyIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2466",
+            "component": "IntelliSensePropertyOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSensePropertyOutlineIcon/IntelliSensePropertyOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4159",
+            "component": "IntelliSenseReferenceOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseReferenceOutlineIcon/IntelliSenseReferenceOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4160",
+            "component": "IntelliSenseSnippetIcon",
+            "source": "src/components/basic-icons/IntelliSenseSnippetIcon/IntelliSenseSnippetIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2556",
+            "component": "IntelliSenseSnippetOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseSnippetOutlineIcon/IntelliSenseSnippetOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4162",
+            "component": "IntelliSenseStructureIcon",
+            "source": "src/components/basic-icons/IntelliSenseStructureIcon/IntelliSenseStructureIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4164",
+            "component": "IntelliSenseTextIcon",
+            "source": "src/components/basic-icons/IntelliSenseTextIcon/IntelliSenseTextIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2514",
+            "component": "IntelliSenseTypeParameterOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseTypeParameterOutlineIcon/IntelliSenseTypeParameterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2498",
+            "component": "IntelliSenseUnitIcon",
+            "source": "src/components/basic-icons/IntelliSenseUnitIcon/IntelliSenseUnitIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1317",
+            "component": "IntelliSenseUnitOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseUnitOutlineIcon/IntelliSenseUnitOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2474",
+            "component": "IntelliSenseValueIcon",
+            "source": "src/components/basic-icons/IntelliSenseValueIcon/IntelliSenseValueIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4199",
+            "component": "IntelliSenseVariableOutlineIcon",
+            "source": "src/components/basic-icons/IntelliSenseVariableOutlineIcon/IntelliSenseVariableOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4268",
+            "component": "ItalicIcon",
+            "source": "src/components/basic-icons/ItalicIcon/ItalicIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7156-695",
+            "component": "KeyboardIcon",
+            "source": "src/components/basic-icons/KeyboardIcon/KeyboardIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7156-703",
+            "component": "KeyboardOutlineIcon",
+            "source": "src/components/basic-icons/KeyboardOutlineIcon/KeyboardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4997-13",
+            "component": "KeyboardTabIcon",
+            "source": "src/components/basic-icons/KeyboardTabIcon/KeyboardTabIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6905-749",
+            "component": "KidIcon",
+            "source": "src/components/basic-icons/KidIcon/KidIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6905-759",
+            "component": "KidOutlineIcon",
+            "source": "src/components/basic-icons/KidOutlineIcon/KidOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9626-458",
+            "component": "LicenseIcon",
+            "source": "src/components/basic-icons/LicenseIcon/LicenseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9301",
+            "component": "LightbulbIcon",
+            "source": "src/components/basic-icons/LightbulbIcon/LightbulbIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9298",
+            "component": "LightbulbOutlineIcon",
+            "source": "src/components/basic-icons/LightbulbOutlineIcon/LightbulbOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2036-984",
+            "component": "LightIcon",
+            "source": "src/components/basic-icons/LightIcon/LightIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4170",
+            "component": "LightningIcon",
+            "source": "src/components/basic-icons/LightningIcon/LightningIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1668",
+            "component": "LightningOutlineIcon",
+            "source": "src/components/basic-icons/LightningOutlineIcon/LightningOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1598",
+            "component": "LightOutlineIcon",
+            "source": "src/components/basic-icons/LightOutlineIcon/LightOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4230",
+            "component": "LikeIcon",
+            "source": "src/components/basic-icons/LikeIcon/LikeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1656",
+            "component": "LikeOutlineIcon",
+            "source": "src/components/basic-icons/LikeOutlineIcon/LikeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1343",
+            "component": "LikeThumbIcon",
+            "source": "src/components/basic-icons/LikeThumbIcon/LikeThumbIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1384",
+            "component": "LikeThumbOutlineIcon",
+            "source": "src/components/basic-icons/LikeThumbOutlineIcon/LikeThumbOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8515-443",
+            "component": "LinearScaleOutlineIcon",
+            "source": "src/components/basic-icons/LinearScaleOutlineIcon/LinearScaleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4790-4",
+            "component": "LineSpacingOutlineIcon",
+            "source": "src/components/basic-icons/LineSpacingOutlineIcon/LineSpacingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4274",
+            "component": "LineStyleOutlineIcon",
+            "source": "src/components/basic-icons/LineStyleOutlineIcon/LineStyleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7974-5822",
+            "component": "LinkOffOutlineIcon",
+            "source": "src/components/basic-icons/LinkOffOutlineIcon/LinkOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4232",
+            "component": "LinkOutlineIcon",
+            "source": "src/components/basic-icons/LinkOutlineIcon/LinkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4261",
+            "component": "ListIcon",
+            "source": "src/components/basic-icons/ListIcon/ListIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4245",
+            "component": "ListNumberedIcon",
+            "source": "src/components/basic-icons/ListNumberedIcon/ListNumberedIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9289",
+            "component": "LiveLessonIcon",
+            "source": "src/components/basic-icons/LiveLessonIcon/LiveLessonIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9286",
+            "component": "LiveLessonOutlineIcon",
+            "source": "src/components/basic-icons/LiveLessonOutlineIcon/LiveLessonOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9241",
+            "component": "LocationIcon",
+            "source": "src/components/basic-icons/LocationIcon/LocationIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9238",
+            "component": "LocationOutlineIcon",
+            "source": "src/components/basic-icons/LocationOutlineIcon/LocationOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1367",
+            "component": "LockIcon",
+            "source": "src/components/basic-icons/LockIcon/LockIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1412",
+            "component": "LockOutlineIcon",
+            "source": "src/components/basic-icons/LockOutlineIcon/LockOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8007-392",
+            "component": "LongTextOutlineIcon",
+            "source": "src/components/basic-icons/LongTextOutlineIcon/LongTextOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2032",
+            "component": "MagicWandIcon",
+            "source": "src/components/basic-icons/MagicWandIcon/MagicWandIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2044",
+            "component": "MagicWandOutlineIcon",
+            "source": "src/components/basic-icons/MagicWandOutlineIcon/MagicWandOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2025",
+            "component": "MailIcon",
+            "source": "src/components/basic-icons/MailIcon/MailIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1868-1000",
+            "component": "MailOutlineIcon",
+            "source": "src/components/basic-icons/MailOutlineIcon/MailOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=502-509",
+            "component": "ManagementOutlineIcon",
+            "source": "src/components/basic-icons/ManagementOutlineIcon/ManagementOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2001",
+            "component": "MarkdownIcon",
+            "source": "src/components/basic-icons/MarkdownIcon/MarkdownIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-1953",
+            "component": "MarkdownOutlineIcon",
+            "source": "src/components/basic-icons/MarkdownOutlineIcon/MarkdownOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2897",
+            "component": "MarkModeIcon",
+            "source": "src/components/basic-icons/MarkModeIcon/MarkModeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4247",
+            "component": "MarkModeOutlineIcon",
+            "source": "src/components/basic-icons/MarkModeOutlineIcon/MarkModeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2999",
+            "component": "MemoIcon",
+            "source": "src/components/basic-icons/MemoIcon/MemoIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3847-4",
+            "component": "MemoOutlineIcon",
+            "source": "src/components/basic-icons/MemoOutlineIcon/MemoOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2367",
+            "component": "MemoryIcon",
+            "source": "src/components/basic-icons/MemoryIcon/MemoryIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4151",
+            "component": "MenuOutlineIcon",
+            "source": "src/components/basic-icons/MenuOutlineIcon/MenuOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4250",
+            "component": "MergeUpOutlineIcon",
+            "source": "src/components/basic-icons/MergeUpOutlineIcon/MergeUpOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4166",
+            "component": "MessageIcon",
+            "source": "src/components/basic-icons/MessageIcon/MessageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1444",
+            "component": "MessageOutlineIcon",
+            "source": "src/components/basic-icons/MessageOutlineIcon/MessageOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4196",
+            "component": "MethodIcon",
+            "source": "src/components/basic-icons/MethodIcon/MethodIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1314",
+            "component": "MethodOutlineIcon",
+            "source": "src/components/basic-icons/MethodOutlineIcon/MethodOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=684-493",
+            "component": "MicOffIcon",
+            "source": "src/components/basic-icons/MicOffIcon/MicOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1657",
+            "component": "MicOffOutlineIcon",
+            "source": "src/components/basic-icons/MicOffOutlineIcon/MicOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=684-490",
+            "component": "MicOnIcon",
+            "source": "src/components/basic-icons/MicOnIcon/MicOnIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1655",
+            "component": "MicOnOutlineIcon",
+            "source": "src/components/basic-icons/MicOnOutlineIcon/MicOnOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2091",
+            "component": "MinusBoxIcon",
+            "source": "src/components/basic-icons/MinusBoxIcon/MinusBoxIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1418",
+            "component": "MinusBoxOutlineIcon",
+            "source": "src/components/basic-icons/MinusBoxOutlineIcon/MinusBoxOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2336",
+            "component": "MinusOutlineIcon",
+            "source": "src/components/basic-icons/MinusOutlineIcon/MinusOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4172",
+            "component": "MoreCommonOutlineIcon",
+            "source": "src/components/basic-icons/MoreCommonOutlineIcon/MoreCommonOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1315",
+            "component": "MovieIcon",
+            "source": "src/components/basic-icons/MovieIcon/MovieIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-1318",
+            "component": "MovieOutlineIcon",
+            "source": "src/components/basic-icons/MovieOutlineIcon/MovieOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1945",
+            "component": "NetfficeOutlineIcon",
+            "source": "src/components/basic-icons/NetfficeOutlineIcon/NetfficeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4174",
+            "component": "NetworkIcon",
+            "source": "src/components/basic-icons/NetworkIcon/NetworkIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1302",
+            "component": "NetworkOutlineIcon",
+            "source": "src/components/basic-icons/NetworkOutlineIcon/NetworkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2275",
+            "component": "NextIcon",
+            "source": "src/components/basic-icons/NextIcon/NextIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1402",
+            "component": "NextOutlineIcon",
+            "source": "src/components/basic-icons/NextOutlineIcon/NextOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-626",
+            "component": "NoImageIcon",
+            "source": "src/components/basic-icons/NoImageIcon/NoImageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1565",
+            "component": "NoImageOutlineIcon",
+            "source": "src/components/basic-icons/NoImageOutlineIcon/NoImageOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1671",
+            "component": "NoticeBoardIcon",
+            "source": "src/components/basic-icons/NoticeBoardIcon/NoticeBoardIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1668",
+            "component": "NoticeBoardOutlineIcon",
+            "source": "src/components/basic-icons/NoticeBoardOutlineIcon/NoticeBoardOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1358",
+            "component": "NoticeCircleIcon",
+            "source": "src/components/basic-icons/NoticeCircleIcon/NoticeCircleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1403",
+            "component": "NoticeCircleOutlineIcon",
+            "source": "src/components/basic-icons/NoticeCircleOutlineIcon/NoticeCircleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1509",
+            "component": "NoUserIcon",
+            "source": "src/components/basic-icons/NoUserIcon/NoUserIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1467",
+            "component": "NoUserOutlineIcon",
+            "source": "src/components/basic-icons/NoUserOutlineIcon/NoUserOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7378-726",
+            "component": "NumberlistOutlineIcon",
+            "source": "src/components/basic-icons/NumberlistOutlineIcon/NumberlistOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4214",
+            "component": "ObjectIcon",
+            "source": "src/components/basic-icons/ObjectIcon/ObjectIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1061-1267",
+            "component": "OpenFileIcon",
+            "source": "src/components/basic-icons/OpenFileIcon/OpenFileIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1471",
+            "component": "OpenFileOutlineIcon",
+            "source": "src/components/basic-icons/OpenFileOutlineIcon/OpenFileOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2452",
+            "component": "OpenFolderIcon",
+            "source": "src/components/basic-icons/OpenFolderIcon/OpenFolderIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1298",
+            "component": "OpenFolderOutlineIcon",
+            "source": "src/components/basic-icons/OpenFolderOutlineIcon/OpenFolderOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1686",
+            "component": "OpenInNewOutlineIcon",
+            "source": "src/components/basic-icons/OpenInNewOutlineIcon/OpenInNewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4206",
+            "component": "OrganizationIcon",
+            "source": "src/components/basic-icons/OrganizationIcon/OrganizationIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1452",
+            "component": "OutOutlineIcon",
+            "source": "src/components/basic-icons/OutOutlineIcon/OutOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4489-1657",
+            "component": "PandasOutlineIcon",
+            "source": "src/components/basic-icons/PandasOutlineIcon/PandasOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4029-20",
+            "component": "PanelOpenIcon",
+            "source": "src/components/basic-icons/PanelOpenIcon/PanelOpenIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2801",
+            "component": "PanelOpenOutlineIcon",
+            "source": "src/components/basic-icons/PanelOpenOutlineIcon/PanelOpenOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9346",
+            "component": "ParentsIcon",
+            "source": "src/components/basic-icons/ParentsIcon/ParentsIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2260",
+            "component": "PauseIcon",
+            "source": "src/components/basic-icons/PauseIcon/PauseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1401",
+            "component": "PauseOutlineIcon",
+            "source": "src/components/basic-icons/PauseOutlineIcon/PauseOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2944",
+            "component": "PcIcon",
+            "source": "src/components/basic-icons/PcIcon/PcIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4260",
+            "component": "PcOutlineIcon",
+            "source": "src/components/basic-icons/PcOutlineIcon/PcOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4234",
+            "component": "PdfIcon",
+            "source": "src/components/basic-icons/PdfIcon/PdfIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1466",
+            "component": "PdfOutlineIcon",
+            "source": "src/components/basic-icons/PdfOutlineIcon/PdfOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2085",
+            "component": "PhoneIcon",
+            "source": "src/components/basic-icons/PhoneIcon/PhoneIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-1701",
+            "component": "PhoneOutlineIcon",
+            "source": "src/components/basic-icons/PhoneOutlineIcon/PhoneOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1683",
+            "component": "PinSetIcon",
+            "source": "src/components/basic-icons/PinSetIcon/PinSetIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1680",
+            "component": "PinSetOutlineIcon",
+            "source": "src/components/basic-icons/PinSetOutlineIcon/PinSetOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4550-14",
+            "component": "PipetteIcon",
+            "source": "src/components/basic-icons/PipetteIcon/PipetteIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2237",
+            "component": "PlansIcon",
+            "source": "src/components/basic-icons/PlansIcon/PlansIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1304",
+            "component": "PlansOutlineIcon",
+            "source": "src/components/basic-icons/PlansOutlineIcon/PlansOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4216",
+            "component": "PlayIcon",
+            "source": "src/components/basic-icons/PlayIcon/PlayIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4236",
+            "component": "PlaylistOutlineIcon",
+            "source": "src/components/basic-icons/PlaylistOutlineIcon/PlaylistOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1399",
+            "component": "PlayOutlineIcon",
+            "source": "src/components/basic-icons/PlayOutlineIcon/PlayOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4177",
+            "component": "PlugInIcon",
+            "source": "src/components/basic-icons/PlugInIcon/PlugInIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2382",
+            "component": "PlugOutIcon",
+            "source": "src/components/basic-icons/PlugOutIcon/PlugOutIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4249",
+            "component": "PlusBoxIcon",
+            "source": "src/components/basic-icons/PlusBoxIcon/PlusBoxIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1417",
+            "component": "PlusBoxOutlineIcon",
+            "source": "src/components/basic-icons/PlusBoxOutlineIcon/PlusBoxOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2358",
+            "component": "PlusOutlineIcon",
+            "source": "src/components/basic-icons/PlusOutlineIcon/PlusOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1061-1274",
+            "component": "PortforwardingIcon",
+            "source": "src/components/basic-icons/PortforwardingIcon/PortforwardingIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1294",
+            "component": "PortforwardingOutlineIcon",
+            "source": "src/components/basic-icons/PortforwardingOutlineIcon/PortforwardingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4778-18",
+            "component": "PowerIcon",
+            "source": "src/components/basic-icons/PowerIcon/PowerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4190",
+            "component": "PreIcon",
+            "source": "src/components/basic-icons/PreIcon/PreIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1398",
+            "component": "PreOutlineIcon",
+            "source": "src/components/basic-icons/PreOutlineIcon/PreOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7081-2303",
+            "component": "PresentScreenIcon",
+            "source": "src/components/basic-icons/PresentScreenIcon/PresentScreenIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7081-2328",
+            "component": "PresentScreenOutlineIcon",
+            "source": "src/components/basic-icons/PresentScreenOutlineIcon/PresentScreenOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=787-436",
+            "component": "PresetOutlineIcon",
+            "source": "src/components/basic-icons/PresetOutlineIcon/PresetOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=68-1",
+            "component": "PreviewIcon",
+            "source": "src/components/basic-icons/PreviewIcon/PreviewIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1491",
+            "component": "PreviewOutlineIcon",
+            "source": "src/components/basic-icons/PreviewOutlineIcon/PreviewOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1893",
+            "component": "PriceOutlineIcon",
+            "source": "src/components/basic-icons/PriceOutlineIcon/PriceOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2051",
+            "component": "PrintIcon",
+            "source": "src/components/basic-icons/PrintIcon/PrintIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1493",
+            "component": "PrintOutlineIcon",
+            "source": "src/components/basic-icons/PrintOutlineIcon/PrintOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4175",
+            "component": "ProjectIcon",
+            "source": "src/components/basic-icons/ProjectIcon/ProjectIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4173",
+            "component": "ProjectOpenIcon",
+            "source": "src/components/basic-icons/ProjectOpenIcon/ProjectOpenIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2935",
+            "component": "ProjectOutlineIcon",
+            "source": "src/components/basic-icons/ProjectOutlineIcon/ProjectOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2154",
+            "component": "ProjectSettingIcon",
+            "source": "src/components/basic-icons/ProjectSettingIcon/ProjectSettingIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1300",
+            "component": "ProjectSettingOutlineIcon",
+            "source": "src/components/basic-icons/ProjectSettingOutlineIcon/ProjectSettingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2218",
+            "component": "PropertyIcon",
+            "source": "src/components/basic-icons/PropertyIcon/PropertyIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9292",
+            "component": "PsychologyIcon",
+            "source": "src/components/basic-icons/PsychologyIcon/PsychologyIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9295",
+            "component": "PsychologyOutlineIcon",
+            "source": "src/components/basic-icons/PsychologyOutlineIcon/PsychologyOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2443",
+            "component": "PublishIcon",
+            "source": "src/components/basic-icons/PublishIcon/PublishIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7724-384",
+            "component": "PublishOutlineIcon",
+            "source": "src/components/basic-icons/PublishOutlineIcon/PublishOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1643",
+            "component": "PullOutlineIcon",
+            "source": "src/components/basic-icons/PullOutlineIcon/PullOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2112",
+            "component": "QnAIcon",
+            "source": "src/components/basic-icons/QnAIcon/QnAIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6639-1404",
+            "component": "QnAOutlineIcon",
+            "source": "src/components/basic-icons/QnAOutlineIcon/QnAOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4264",
+            "component": "QrcodeOutlineIcon",
+            "source": "src/components/basic-icons/QrcodeOutlineIcon/QrcodeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2106",
+            "component": "QuoteIcon",
+            "source": "src/components/basic-icons/QuoteIcon/QuoteIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2194",
+            "component": "QuoteOutlineIcon",
+            "source": "src/components/basic-icons/QuoteOutlineIcon/QuoteOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3878-7",
+            "component": "ReferenceIcon",
+            "source": "src/components/basic-icons/ReferenceIcon/ReferenceIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-2114",
+            "component": "ReferenceOutlineIcon",
+            "source": "src/components/basic-icons/ReferenceOutlineIcon/ReferenceOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1674",
+            "component": "RefreshOutlineIcon",
+            "source": "src/components/basic-icons/RefreshOutlineIcon/RefreshOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4213",
+            "component": "RegexOutlineIcon",
+            "source": "src/components/basic-icons/RegexOutlineIcon/RegexOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1677",
+            "component": "ReloadOutlineIcon",
+            "source": "src/components/basic-icons/ReloadOutlineIcon/ReloadOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2461",
+            "component": "RemoteIcon",
+            "source": "src/components/basic-icons/RemoteIcon/RemoteIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=406-504",
+            "component": "RemoteOffIcon",
+            "source": "src/components/basic-icons/RemoteOffIcon/RemoteOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2729",
+            "component": "RemoteOffOutlineIcon",
+            "source": "src/components/basic-icons/RemoteOffOutlineIcon/RemoteOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2717",
+            "component": "RemoteOutlineIcon",
+            "source": "src/components/basic-icons/RemoteOutlineIcon/RemoteOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2428",
+            "component": "ReplaceIcon",
+            "source": "src/components/basic-icons/ReplaceIcon/ReplaceIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4244",
+            "component": "ReplyOutlineIcon",
+            "source": "src/components/basic-icons/ReplyOutlineIcon/ReplyOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-1007",
+            "component": "RestaurantOutlineIcon",
+            "source": "src/components/basic-icons/RestaurantOutlineIcon/RestaurantOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4267",
+            "component": "ResultManagementIcon",
+            "source": "src/components/basic-icons/ResultManagementIcon/ResultManagementIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2884",
+            "component": "ResultManagementOutlineIcon",
+            "source": "src/components/basic-icons/ResultManagementOutlineIcon/ResultManagementOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9626-457",
+            "component": "RewardedAdsIcon",
+            "source": "src/components/basic-icons/RewardedAdsIcon/RewardedAdsIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9250",
+            "component": "RouteIcon",
+            "source": "src/components/basic-icons/RouteIcon/RouteIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9253",
+            "component": "RouteOutlineIcon",
+            "source": "src/components/basic-icons/RouteOutlineIcon/RouteOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4195",
+            "component": "RunIcon",
+            "source": "src/components/basic-icons/RunIcon/RunIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2875",
+            "component": "RunOutlineIcon",
+            "source": "src/components/basic-icons/RunOutlineIcon/RunOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4188",
+            "component": "SaveAsIcon",
+            "source": "src/components/basic-icons/SaveAsIcon/SaveAsIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1296",
+            "component": "SaveAsOutlineIcon",
+            "source": "src/components/basic-icons/SaveAsOutlineIcon/SaveAsOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4192",
+            "component": "SaveIcon",
+            "source": "src/components/basic-icons/SaveIcon/SaveIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2868",
+            "component": "SaveOutlineIcon",
+            "source": "src/components/basic-icons/SaveOutlineIcon/SaveOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1824-982",
+            "component": "SavingIcon",
+            "source": "src/components/basic-icons/SavingIcon/SavingIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6629-2287",
+            "component": "SavingOutlineIcon",
+            "source": "src/components/basic-icons/SavingOutlineIcon/SavingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4836-539",
+            "component": "SbomIcon",
+            "source": "src/components/basic-icons/SbomIcon/SbomIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9343",
+            "component": "SchoolIcon",
+            "source": "src/components/basic-icons/SchoolIcon/SchoolIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9333",
+            "component": "SchoolOutlineIcon",
+            "source": "src/components/basic-icons/SchoolOutlineIcon/SchoolOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1458",
+            "component": "SearchOutlineIcon",
+            "source": "src/components/basic-icons/SearchOutlineIcon/SearchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1524",
+            "component": "SendIcon",
+            "source": "src/components/basic-icons/SendIcon/SendIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1497",
+            "component": "SendOutlineIcon",
+            "source": "src/components/basic-icons/SendOutlineIcon/SendOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1692",
+            "component": "SettingIcon",
+            "source": "src/components/basic-icons/SettingIcon/SettingIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1689",
+            "component": "SettingOutlineIcon",
+            "source": "src/components/basic-icons/SettingOutlineIcon/SettingOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1527",
+            "component": "ShareIcon",
+            "source": "src/components/basic-icons/ShareIcon/ShareIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1496",
+            "component": "ShareOutlineIcon",
+            "source": "src/components/basic-icons/ShareOutlineIcon/ShareOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4239",
+            "component": "ShoppingCartIcon",
+            "source": "src/components/basic-icons/ShoppingCartIcon/ShoppingCartIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-3007",
+            "component": "ShoppingCartOutlineIcon",
+            "source": "src/components/basic-icons/ShoppingCartOutlineIcon/ShoppingCartOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=741-432",
+            "component": "ShortcutOutlineIcon",
+            "source": "src/components/basic-icons/ShortcutOutlineIcon/ShortcutOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8007-389",
+            "component": "ShortTextOutlineIcon",
+            "source": "src/components/basic-icons/ShortTextOutlineIcon/ShortTextOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8587-790",
+            "component": "SideNavIcon",
+            "source": "src/components/basic-icons/SideNavIcon/SideNavIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8769-405",
+            "component": "SideNavOutlineIcon",
+            "source": "src/components/basic-icons/SideNavOutlineIcon/SideNavOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=710-441",
+            "component": "SignalPowerOutlineIcon",
+            "source": "src/components/basic-icons/SignalPowerOutlineIcon/SignalPowerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4225",
+            "component": "SlashOutlineIcon",
+            "source": "src/components/basic-icons/SlashOutlineIcon/SlashOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8444-394",
+            "component": "SlotIcon",
+            "source": "src/components/basic-icons/SlotIcon/SlotIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=777-450",
+            "component": "SoundOffIcon",
+            "source": "src/components/basic-icons/SoundOffIcon/SoundOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1576",
+            "component": "SoundOffOutlineIcon",
+            "source": "src/components/basic-icons/SoundOffOutlineIcon/SoundOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=777-449",
+            "component": "SoundOnIcon",
+            "source": "src/components/basic-icons/SoundOnIcon/SoundOnIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1575",
+            "component": "SoundOnOutlineIcon",
+            "source": "src/components/basic-icons/SoundOnOutlineIcon/SoundOnOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4156",
+            "component": "SourcecodeIcon",
+            "source": "src/components/basic-icons/SourcecodeIcon/SourcecodeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1062-1261",
+            "component": "SpinnerOutlineIcon",
+            "source": "src/components/basic-icons/SpinnerOutlineIcon/SpinnerOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2317",
+            "component": "SplitHorizontalOutlineIcon",
+            "source": "src/components/basic-icons/SplitHorizontalOutlineIcon/SplitHorizontalOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4262",
+            "component": "SplitIcon",
+            "source": "src/components/basic-icons/SplitIcon/SplitIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2294",
+            "component": "SplitVerticalOutlineIcon",
+            "source": "src/components/basic-icons/SplitVerticalOutlineIcon/SplitVerticalOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=451-494",
+            "component": "SshIcon",
+            "source": "src/components/basic-icons/SshIcon/SshIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1887",
+            "component": "StarIcon",
+            "source": "src/components/basic-icons/StarIcon/StarIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1918",
+            "component": "StarOutlineIcon",
+            "source": "src/components/basic-icons/StarOutlineIcon/StarOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4167",
+            "component": "StepInOutlineIcon",
+            "source": "src/components/basic-icons/StepInOutlineIcon/StepInOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2457",
+            "component": "StepOutOutlineIcon",
+            "source": "src/components/basic-icons/StepOutOutlineIcon/StepOutOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4171",
+            "component": "StepOverOutlineIcon",
+            "source": "src/components/basic-icons/StepOverOutlineIcon/StepOverOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2216",
+            "component": "StopIcon",
+            "source": "src/components/basic-icons/StopIcon/StopIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1318",
+            "component": "StopOutlineIcon",
+            "source": "src/components/basic-icons/StopOutlineIcon/StopOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2538",
+            "component": "StorageIcon",
+            "source": "src/components/basic-icons/StorageIcon/StorageIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9120-374",
+            "component": "StrikeOutlineIcon",
+            "source": "src/components/basic-icons/StrikeOutlineIcon/StrikeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4220",
+            "component": "StruckIcon",
+            "source": "src/components/basic-icons/StruckIcon/StruckIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7080-1308",
+            "component": "StruckOutlineIcon",
+            "source": "src/components/basic-icons/StruckOutlineIcon/StruckOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9259",
+            "component": "StudentManagementIcon",
+            "source": "src/components/basic-icons/StudentManagementIcon/StudentManagementIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9256",
+            "component": "StudentManagementOutlineIcon",
+            "source": "src/components/basic-icons/StudentManagementOutlineIcon/StudentManagementOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4237",
+            "component": "SyllabusIcon",
+            "source": "src/components/basic-icons/SyllabusIcon/SyllabusIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6665-2928",
+            "component": "SyllabusOutlineIcon",
+            "source": "src/components/basic-icons/SyllabusOutlineIcon/SyllabusOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1435",
+            "component": "TableFilterOutlineIcon",
+            "source": "src/components/basic-icons/TableFilterOutlineIcon/TableFilterOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4271",
+            "component": "TableOutlineIcon",
+            "source": "src/components/basic-icons/TableOutlineIcon/TableOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2060",
+            "component": "TabletIcon",
+            "source": "src/components/basic-icons/TabletIcon/TabletIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6634-1718",
+            "component": "TabletOutlineIcon",
+            "source": "src/components/basic-icons/TabletOutlineIcon/TabletOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6785-9244",
+            "component": "TakeoffIcon",
+            "source": "src/components/basic-icons/TakeoffIcon/TakeoffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=531-525",
+            "component": "TerminalConnectOutlineIcon",
+            "source": "src/components/basic-icons/TerminalConnectOutlineIcon/TerminalConnectOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-1889",
+            "component": "TerminalOutlineIcon",
+            "source": "src/components/basic-icons/TerminalOutlineIcon/TerminalOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4227",
+            "component": "TerminalWindowOutlineIcon",
+            "source": "src/components/basic-icons/TerminalWindowOutlineIcon/TerminalWindowOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2351-145",
+            "component": "TestIcon",
+            "source": "src/components/basic-icons/TestIcon/TestIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6661-2644",
+            "component": "TestOutlineIcon",
+            "source": "src/components/basic-icons/TestOutlineIcon/TestOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4272",
+            "component": "TextColorOutlineIcon",
+            "source": "src/components/basic-icons/TextColorOutlineIcon/TextColorOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4231",
+            "component": "TextOutlineIcon",
+            "source": "src/components/basic-icons/TextOutlineIcon/TextOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8402-6388",
+            "component": "TextScanOutlineIcon",
+            "source": "src/components/basic-icons/TextScanOutlineIcon/TextScanOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1530",
+            "component": "TimeIcon",
+            "source": "src/components/basic-icons/TimeIcon/TimeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1500",
+            "component": "TimeOutlineIcon",
+            "source": "src/components/basic-icons/TimeOutlineIcon/TimeOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4203",
+            "component": "TransferOutlineIcon",
+            "source": "src/components/basic-icons/TransferOutlineIcon/TransferOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4719-19",
+            "component": "TranslateOutlineIcon",
+            "source": "src/components/basic-icons/TranslateOutlineIcon/TranslateOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1373",
+            "component": "TrashIcon",
+            "source": "src/components/basic-icons/TrashIcon/TrashIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1418",
+            "component": "TrashOutlineIcon",
+            "source": "src/components/basic-icons/TrashOutlineIcon/TrashOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1556-977",
+            "component": "TreeCollapseIcon",
+            "source": "src/components/basic-icons/TreeCollapseIcon/TreeCollapseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9496-371",
+            "component": "TriangleOutlineIcon",
+            "source": "src/components/basic-icons/TriangleOutlineIcon/TriangleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7610-384",
+            "component": "TwoFileIcon",
+            "source": "src/components/basic-icons/TwoFileIcon/TwoFileIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4258",
+            "component": "UnderlineOutlineIcon",
+            "source": "src/components/basic-icons/UnderlineOutlineIcon/UnderlineOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6712-1430",
+            "component": "UndoOutlineIcon",
+            "source": "src/components/basic-icons/UndoOutlineIcon/UndoOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1370",
+            "component": "UnlockIcon",
+            "source": "src/components/basic-icons/UnlockIcon/UnlockIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1415",
+            "component": "UnlockOutlineIcon",
+            "source": "src/components/basic-icons/UnlockOutlineIcon/UnlockOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1332",
+            "component": "UploadIcon",
+            "source": "src/components/basic-icons/UploadIcon/UploadIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1376",
+            "component": "UploadOutlineIcon",
+            "source": "src/components/basic-icons/UploadOutlineIcon/UploadOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4222",
+            "component": "UppercaseIcon",
+            "source": "src/components/basic-icons/UppercaseIcon/UppercaseIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1515",
+            "component": "UserCheckIcon",
+            "source": "src/components/basic-icons/UserCheckIcon/UserCheckIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1473",
+            "component": "UserCheckOutlineIcon",
+            "source": "src/components/basic-icons/UserCheckOutlineIcon/UserCheckOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1506",
+            "component": "UserIcon",
+            "source": "src/components/basic-icons/UserIcon/UserIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1521",
+            "component": "UserMoveIcon",
+            "source": "src/components/basic-icons/UserMoveIcon/UserMoveIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1481",
+            "component": "UserMoveOutlineIcon",
+            "source": "src/components/basic-icons/UserMoveOutlineIcon/UserMoveOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1464",
+            "component": "UserOutlineIcon",
+            "source": "src/components/basic-icons/UserOutlineIcon/UserOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7359-734",
+            "component": "UserSearchIcon",
+            "source": "src/components/basic-icons/UserSearchIcon/UserSearchIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7359-733",
+            "component": "UserSearchOutlineIcon",
+            "source": "src/components/basic-icons/UserSearchOutlineIcon/UserSearchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4189",
+            "component": "VariableIcon",
+            "source": "src/components/basic-icons/VariableIcon/VariableIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=684-497",
+            "component": "VideocamOffIcon",
+            "source": "src/components/basic-icons/VideocamOffIcon/VideocamOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1643",
+            "component": "VideocamOffOutlineIcon",
+            "source": "src/components/basic-icons/VideocamOffOutlineIcon/VideocamOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=684-488",
+            "component": "VideocamOnIcon",
+            "source": "src/components/basic-icons/VideocamOnIcon/VideocamOnIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1642",
+            "component": "VideocamOnOutlineIcon",
+            "source": "src/components/basic-icons/VideocamOnOutlineIcon/VideocamOnOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4185",
+            "component": "ViewExpandOutlineIcon",
+            "source": "src/components/basic-icons/ViewExpandOutlineIcon/ViewExpandOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-631",
+            "component": "ViewModuleIcon",
+            "source": "src/components/basic-icons/ViewModuleIcon/ViewModuleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6624-1667",
+            "component": "ViewModuleOutlineIcon",
+            "source": "src/components/basic-icons/ViewModuleOutlineIcon/ViewModuleOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1446",
+            "component": "ViewOffIcon",
+            "source": "src/components/basic-icons/ViewOffIcon/ViewOffIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1430",
+            "component": "ViewOffOutlineIcon",
+            "source": "src/components/basic-icons/ViewOffOutlineIcon/ViewOffOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1443",
+            "component": "ViewOnIcon",
+            "source": "src/components/basic-icons/ViewOnIcon/ViewOnIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1427",
+            "component": "ViewOnOutlineIcon",
+            "source": "src/components/basic-icons/ViewOnOutlineIcon/ViewOnOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2338",
+            "component": "ViewShrinkOutlineIcon",
+            "source": "src/components/basic-icons/ViewShrinkOutlineIcon/ViewShrinkOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1364",
+            "component": "WarningIcon",
+            "source": "src/components/basic-icons/WarningIcon/WarningIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6713-1409",
+            "component": "WarningOutlineIcon",
+            "source": "src/components/basic-icons/WarningOutlineIcon/WarningOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2299",
+            "component": "WordMatchIcon",
+            "source": "src/components/basic-icons/WordMatchIcon/WordMatchIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4169",
+            "component": "WordSearchOutlineIcon",
+            "source": "src/components/basic-icons/WordSearchOutlineIcon/WordSearchOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-4155",
+            "component": "ZoomInOutlineIcon",
+            "source": "src/components/basic-icons/ZoomInOutlineIcon/ZoomInOutlineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2-2447",
+            "component": "ZoomOutOutlineIcon",
+            "source": "src/components/basic-icons/ZoomOutOutlineIcon/ZoomOutOutlineIcon.tsx"
+        }
+    ]
+}

--- a/packages/icons/src/icons-symbol.figma.batch.json
+++ b/packages/icons/src/icons-symbol.figma.batch.json
@@ -1,0 +1,1295 @@
+{
+    "templateFile": "./icon.figma.batch.ts",
+    "components": [
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1349",
+            "component": "AfghanistanColorIcon",
+            "source": "src/components/symbol-icons/AfghanistanColorIcon/AfghanistanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1284",
+            "component": "AlbaniaColorIcon",
+            "source": "src/components/symbol-icons/AlbaniaColorIcon/AlbaniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1363",
+            "component": "AlgeriaColorIcon",
+            "source": "src/components/symbol-icons/AlgeriaColorIcon/AlgeriaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1417",
+            "component": "AndorraColorIcon",
+            "source": "src/components/symbol-icons/AndorraColorIcon/AndorraColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1419",
+            "component": "AngolaColorIcon",
+            "source": "src/components/symbol-icons/AngolaColorIcon/AngolaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1414",
+            "component": "AntiguaAndBarbudaColorIcon",
+            "source": "src/components/symbol-icons/AntiguaAndBarbudaColorIcon/AntiguaAndBarbudaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1028",
+            "component": "AppleIcon",
+            "source": "src/components/symbol-icons/AppleIcon/AppleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1446",
+            "component": "ArgentinaColorIcon",
+            "source": "src/components/symbol-icons/ArgentinaColorIcon/ArgentinaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1365",
+            "component": "ArmeniaColorIcon",
+            "source": "src/components/symbol-icons/ArmeniaColorIcon/ArmeniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1318",
+            "component": "AustraliaColorIcon",
+            "source": "src/components/symbol-icons/AustraliaColorIcon/AustraliaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1300",
+            "component": "AustriaColorIcon",
+            "source": "src/components/symbol-icons/AustriaColorIcon/AustriaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-102",
+            "component": "AwsIcon",
+            "source": "src/components/symbol-icons/AwsIcon/AwsIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1418",
+            "component": "AzerbaijanColorIcon",
+            "source": "src/components/symbol-icons/AzerbaijanColorIcon/AzerbaijanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-108",
+            "component": "AzureIcon",
+            "source": "src/components/symbol-icons/AzureIcon/AzureIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1319",
+            "component": "BahamasColorIcon",
+            "source": "src/components/symbol-icons/BahamasColorIcon/BahamasColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1317",
+            "component": "BahrainColorIcon",
+            "source": "src/components/symbol-icons/BahrainColorIcon/BahrainColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1360",
+            "component": "BangladeshColorIcon",
+            "source": "src/components/symbol-icons/BangladeshColorIcon/BangladeshColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1366",
+            "component": "BarbadosColorIcon",
+            "source": "src/components/symbol-icons/BarbadosColorIcon/BarbadosColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1385",
+            "component": "BelarusColorIcon",
+            "source": "src/components/symbol-icons/BelarusColorIcon/BelarusColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1309",
+            "component": "BelgiumColorIcon",
+            "source": "src/components/symbol-icons/BelgiumColorIcon/BelgiumColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1346",
+            "component": "BelizeColorIcon",
+            "source": "src/components/symbol-icons/BelizeColorIcon/BelizeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1268",
+            "component": "BeninColorIcon",
+            "source": "src/components/symbol-icons/BeninColorIcon/BeninColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1389",
+            "component": "BhutanColorIcon",
+            "source": "src/components/symbol-icons/BhutanColorIcon/BhutanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=561-494",
+            "component": "BitbucketIcon",
+            "source": "src/components/symbol-icons/BitbucketIcon/BitbucketIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1015",
+            "component": "BlogColorIcon",
+            "source": "src/components/symbol-icons/BlogColorIcon/BlogColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1011",
+            "component": "BlogIcon",
+            "source": "src/components/symbol-icons/BlogIcon/BlogIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1423",
+            "component": "BoliviaColorIcon",
+            "source": "src/components/symbol-icons/BoliviaColorIcon/BoliviaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1310",
+            "component": "BosniaAndHerzegovinaColorIcon",
+            "source": "src/components/symbol-icons/BosniaAndHerzegovinaColorIcon/BosniaAndHerzegovinaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1278",
+            "component": "BotswanaColorIcon",
+            "source": "src/components/symbol-icons/BotswanaColorIcon/BotswanaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1332",
+            "component": "BrazilColorIcon",
+            "source": "src/components/symbol-icons/BrazilColorIcon/BrazilColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1412",
+            "component": "BruneiColorIcon",
+            "source": "src/components/symbol-icons/BruneiColorIcon/BruneiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1308",
+            "component": "BulgariaColorIcon",
+            "source": "src/components/symbol-icons/BulgariaColorIcon/BulgariaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1315",
+            "component": "BurkinaFasoColorIcon",
+            "source": "src/components/symbol-icons/BurkinaFasoColorIcon/BurkinaFasoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1269",
+            "component": "BurundiColorIcon",
+            "source": "src/components/symbol-icons/BurundiColorIcon/BurundiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1378",
+            "component": "CambodiaColorIcon",
+            "source": "src/components/symbol-icons/CambodiaColorIcon/CambodiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1266",
+            "component": "CameroonColorIcon",
+            "source": "src/components/symbol-icons/CameroonColorIcon/CameroonColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1443",
+            "component": "CanadaColorIcon",
+            "source": "src/components/symbol-icons/CanadaColorIcon/CanadaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1277",
+            "component": "CapeVerdeColorIcon",
+            "source": "src/components/symbol-icons/CapeVerdeColorIcon/CapeVerdeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1263",
+            "component": "CentralAfricanRepublicColorIcon",
+            "source": "src/components/symbol-icons/CentralAfricanRepublicColorIcon/CentralAfricanRepublicColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1264",
+            "component": "ChadColorIcon",
+            "source": "src/components/symbol-icons/ChadColorIcon/ChadColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=5310-75",
+            "component": "ChatgptIcon",
+            "source": "src/components/symbol-icons/ChatgptIcon/ChatgptIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1415",
+            "component": "ChileColorIcon",
+            "source": "src/components/symbol-icons/ChileColorIcon/ChileColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1370",
+            "component": "ChinaColorIcon",
+            "source": "src/components/symbol-icons/ChinaColorIcon/ChinaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2954",
+            "component": "ChromeColorIcon",
+            "source": "src/components/symbol-icons/ChromeColorIcon/ChromeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7474-157",
+            "component": "ChromeIcon",
+            "source": "src/components/symbol-icons/ChromeIcon/ChromeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1421",
+            "component": "ColombiaColorIcon",
+            "source": "src/components/symbol-icons/ColombiaColorIcon/ColombiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1259",
+            "component": "ComorosColorIcon",
+            "source": "src/components/symbol-icons/ComorosColorIcon/ComorosColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1333",
+            "component": "CookIslandsColorIcon",
+            "source": "src/components/symbol-icons/CookIslandsColorIcon/CookIslandsColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1330",
+            "component": "CostaRicaColorIcon",
+            "source": "src/components/symbol-icons/CostaRicaColorIcon/CostaRicaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1289",
+            "component": "CroatiaColorIcon",
+            "source": "src/components/symbol-icons/CroatiaColorIcon/CroatiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1407",
+            "component": "CubaColorIcon",
+            "source": "src/components/symbol-icons/CubaColorIcon/CubaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1288",
+            "component": "CyprusColorIcon",
+            "source": "src/components/symbol-icons/CyprusColorIcon/CyprusColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1439",
+            "component": "CzechRepublicColorIcon",
+            "source": "src/components/symbol-icons/CzechRepublicColorIcon/CzechRepublicColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1257",
+            "component": "DemocraticRepublicOfTheCongoColorIcon",
+            "source": "src/components/symbol-icons/DemocraticRepublicOfTheCongoColorIcon/DemocraticRepublicOfTheCongoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1299",
+            "component": "DenmarkColorIcon",
+            "source": "src/components/symbol-icons/DenmarkColorIcon/DenmarkColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7882-83",
+            "component": "DiscordColorIcon",
+            "source": "src/components/symbol-icons/DiscordColorIcon/DiscordColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3953-4",
+            "component": "DiscordIcon",
+            "source": "src/components/symbol-icons/DiscordIcon/DiscordIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1323",
+            "component": "DjiboutiColorIcon",
+            "source": "src/components/symbol-icons/DjiboutiColorIcon/DjiboutiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-114",
+            "component": "DockerIcon",
+            "source": "src/components/symbol-icons/DockerIcon/DockerIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1442",
+            "component": "DominicaColorIcon",
+            "source": "src/components/symbol-icons/DominicaColorIcon/DominicaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1413",
+            "component": "DominicanRepublicColorIcon",
+            "source": "src/components/symbol-icons/DominicanRepublicColorIcon/DominicanRepublicColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1364",
+            "component": "EastTimorColorIcon",
+            "source": "src/components/symbol-icons/EastTimorColorIcon/EastTimorColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1433",
+            "component": "EcuadorColorIcon",
+            "source": "src/components/symbol-icons/EcuadorColorIcon/EcuadorColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1345",
+            "component": "EgyptColorIcon",
+            "source": "src/components/symbol-icons/EgyptColorIcon/EgyptColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1410",
+            "component": "ElSalvadorColorIcon",
+            "source": "src/components/symbol-icons/ElSalvadorColorIcon/ElSalvadorColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1267",
+            "component": "EquatorialGuineaColorIcon",
+            "source": "src/components/symbol-icons/EquatorialGuineaColorIcon/EquatorialGuineaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1405",
+            "component": "EritreaColorIcon",
+            "source": "src/components/symbol-icons/EritreaColorIcon/EritreaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1298",
+            "component": "EstoniaColorIcon",
+            "source": "src/components/symbol-icons/EstoniaColorIcon/EstoniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1382",
+            "component": "EswatiniColorIcon",
+            "source": "src/components/symbol-icons/EswatiniColorIcon/EswatiniColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1375",
+            "component": "EthiopiaColorIcon",
+            "source": "src/components/symbol-icons/EthiopiaColorIcon/EthiopiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2679-151",
+            "component": "FacebookColorIcon",
+            "source": "src/components/symbol-icons/FacebookColorIcon/FacebookColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1021",
+            "component": "FacebookIcon",
+            "source": "src/components/symbol-icons/FacebookIcon/FacebookIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4647-84",
+            "component": "FigmaColorIcon",
+            "source": "src/components/symbol-icons/FigmaColorIcon/FigmaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4647-83",
+            "component": "FigmaIcon",
+            "source": "src/components/symbol-icons/FigmaIcon/FigmaIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1427",
+            "component": "FijiColorIcon",
+            "source": "src/components/symbol-icons/FijiColorIcon/FijiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1307",
+            "component": "FinlandColorIcon",
+            "source": "src/components/symbol-icons/FinlandColorIcon/FinlandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2955",
+            "component": "FirefoxColorIcon",
+            "source": "src/components/symbol-icons/FirefoxColorIcon/FirefoxColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1312",
+            "component": "FranceColorIcon",
+            "source": "src/components/symbol-icons/FranceColorIcon/FranceColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1254",
+            "component": "GabonColorIcon",
+            "source": "src/components/symbol-icons/GabonColorIcon/GabonColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1253",
+            "component": "GambiaColorIcon",
+            "source": "src/components/symbol-icons/GambiaColorIcon/GambiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-112",
+            "component": "GcpIcon",
+            "source": "src/components/symbol-icons/GcpIcon/GcpIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1357",
+            "component": "GeorgiaColorIcon",
+            "source": "src/components/symbol-icons/GeorgiaColorIcon/GeorgiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1301",
+            "component": "GermanyColorIcon",
+            "source": "src/components/symbol-icons/GermanyColorIcon/GermanyColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1393",
+            "component": "GhanaColorIcon",
+            "source": "src/components/symbol-icons/GhanaColorIcon/GhanaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4710-93",
+            "component": "GithubColorIcon",
+            "source": "src/components/symbol-icons/GithubColorIcon/GithubColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4-574",
+            "component": "GithubIcon",
+            "source": "src/components/symbol-icons/GithubIcon/GithubIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-110",
+            "component": "GitlabIcon",
+            "source": "src/components/symbol-icons/GitlabIcon/GitlabIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-87",
+            "component": "GoogleCalendarIcon",
+            "source": "src/components/symbol-icons/GoogleCalendarIcon/GoogleCalendarIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1006",
+            "component": "GoogleColorIcon",
+            "source": "src/components/symbol-icons/GoogleColorIcon/GoogleColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7735-497",
+            "component": "GoogleIcon",
+            "source": "src/components/symbol-icons/GoogleIcon/GoogleIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1386",
+            "component": "GreeceColorIcon",
+            "source": "src/components/symbol-icons/GreeceColorIcon/GreeceColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1424",
+            "component": "GrenadaColorIcon",
+            "source": "src/components/symbol-icons/GrenadaColorIcon/GrenadaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1440",
+            "component": "GuatemalaColorIcon",
+            "source": "src/components/symbol-icons/GuatemalaColorIcon/GuatemalaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1251",
+            "component": "GuineaBissauColorIcon",
+            "source": "src/components/symbol-icons/GuineaBissauColorIcon/GuineaBissauColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1252",
+            "component": "GuineaColorIcon",
+            "source": "src/components/symbol-icons/GuineaColorIcon/GuineaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1373",
+            "component": "GuyanaColorIcon",
+            "source": "src/components/symbol-icons/GuyanaColorIcon/GuyanaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1395",
+            "component": "HaitiColorIcon",
+            "source": "src/components/symbol-icons/HaitiColorIcon/HaitiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1431",
+            "component": "HondurasColorIcon",
+            "source": "src/components/symbol-icons/HondurasColorIcon/HondurasColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1390",
+            "component": "HungaryColorIcon",
+            "source": "src/components/symbol-icons/HungaryColorIcon/HungaryColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1283",
+            "component": "IcelandColorIcon",
+            "source": "src/components/symbol-icons/IcelandColorIcon/IcelandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1396",
+            "component": "IndiaColorIcon",
+            "source": "src/components/symbol-icons/IndiaColorIcon/IndiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1379",
+            "component": "IndonesiaColorIcon",
+            "source": "src/components/symbol-icons/IndonesiaColorIcon/IndonesiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1014",
+            "component": "InstagramColorIcon",
+            "source": "src/components/symbol-icons/InstagramColorIcon/InstagramColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1010",
+            "component": "InstagramIcon",
+            "source": "src/components/symbol-icons/InstagramIcon/InstagramIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=2880-79",
+            "component": "IntellijColorIcon",
+            "source": "src/components/symbol-icons/IntellijColorIcon/IntellijColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1429",
+            "component": "IranColorIcon",
+            "source": "src/components/symbol-icons/IranColorIcon/IranColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1335",
+            "component": "IraqColorIcon",
+            "source": "src/components/symbol-icons/IraqColorIcon/IraqColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1285",
+            "component": "IrelandColorIcon",
+            "source": "src/components/symbol-icons/IrelandColorIcon/IrelandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1338",
+            "component": "IsraelColorIcon",
+            "source": "src/components/symbol-icons/IsraelColorIcon/IsraelColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1293",
+            "component": "ItalyColorIcon",
+            "source": "src/components/symbol-icons/ItalyColorIcon/ItalyColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1321",
+            "component": "IvoryCoastColorIcon",
+            "source": "src/components/symbol-icons/IvoryCoastColorIcon/IvoryCoastColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1432",
+            "component": "JamaicaColorIcon",
+            "source": "src/components/symbol-icons/JamaicaColorIcon/JamaicaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1367",
+            "component": "JapanColorIcon",
+            "source": "src/components/symbol-icons/JapanColorIcon/JapanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-82",
+            "component": "JiraIcon",
+            "source": "src/components/symbol-icons/JiraIcon/JiraIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1316",
+            "component": "JordanColorIcon",
+            "source": "src/components/symbol-icons/JordanColorIcon/JordanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2952",
+            "component": "JupyterColorIcon",
+            "source": "src/components/symbol-icons/JupyterColorIcon/JupyterColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3319-106",
+            "component": "JupyterlabColorIcon",
+            "source": "src/components/symbol-icons/JupyterlabColorIcon/JupyterlabColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7730-477",
+            "component": "JupyterlabIcon",
+            "source": "src/components/symbol-icons/JupyterlabIcon/JupyterlabIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1020",
+            "component": "KakaoIcon",
+            "source": "src/components/symbol-icons/KakaoIcon/KakaoIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1444",
+            "component": "KazakhstanColorIcon",
+            "source": "src/components/symbol-icons/KazakhstanColorIcon/KazakhstanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1402",
+            "component": "KenyaColorIcon",
+            "source": "src/components/symbol-icons/KenyaColorIcon/KenyaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1344",
+            "component": "KiribatiColorIcon",
+            "source": "src/components/symbol-icons/KiribatiColorIcon/KiribatiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1290",
+            "component": "KosovoColorIcon",
+            "source": "src/components/symbol-icons/KosovoColorIcon/KosovoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=3304-87",
+            "component": "KrampolineIcon",
+            "source": "src/components/symbol-icons/KrampolineIcon/KrampolineIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-116",
+            "component": "KubernatesIcon",
+            "source": "src/components/symbol-icons/KubernatesIcon/KubernatesIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1341",
+            "component": "KuwaitColorIcon",
+            "source": "src/components/symbol-icons/KuwaitColorIcon/KuwaitColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1354",
+            "component": "KyrgyzstanColorIcon",
+            "source": "src/components/symbol-icons/KyrgyzstanColorIcon/KyrgyzstanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1387",
+            "component": "LaosColorIcon",
+            "source": "src/components/symbol-icons/LaosColorIcon/LaosColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1302",
+            "component": "LatviaColorIcon",
+            "source": "src/components/symbol-icons/LatviaColorIcon/LatviaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1326",
+            "component": "LebanonColorIcon",
+            "source": "src/components/symbol-icons/LebanonColorIcon/LebanonColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1292",
+            "component": "LesothoColorIcon",
+            "source": "src/components/symbol-icons/LesothoColorIcon/LesothoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1280",
+            "component": "LiberiaColorIcon",
+            "source": "src/components/symbol-icons/LiberiaColorIcon/LiberiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1281",
+            "component": "LibyaColorIcon",
+            "source": "src/components/symbol-icons/LibyaColorIcon/LibyaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1303",
+            "component": "LiechtensteinColorIcon",
+            "source": "src/components/symbol-icons/LiechtensteinColorIcon/LiechtensteinColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7200-79",
+            "component": "LinkedinIcon",
+            "source": "src/components/symbol-icons/LinkedinIcon/LinkedinIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1384",
+            "component": "LithuaniaColorIcon",
+            "source": "src/components/symbol-icons/LithuaniaColorIcon/LithuaniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1304",
+            "component": "LuxembourgColorIcon",
+            "source": "src/components/symbol-icons/LuxembourgColorIcon/LuxembourgColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1276",
+            "component": "MadagascarColorIcon",
+            "source": "src/components/symbol-icons/MadagascarColorIcon/MadagascarColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1426",
+            "component": "MalawiColorIcon",
+            "source": "src/components/symbol-icons/MalawiColorIcon/MalawiColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1347",
+            "component": "MalaysiaColorIcon",
+            "source": "src/components/symbol-icons/MalaysiaColorIcon/MalaysiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1411",
+            "component": "MaldivesColorIcon",
+            "source": "src/components/symbol-icons/MaldivesColorIcon/MaldivesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1275",
+            "component": "MaliColorIcon",
+            "source": "src/components/symbol-icons/MaliColorIcon/MaliColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1313",
+            "component": "MaltaColorIcon",
+            "source": "src/components/symbol-icons/MaltaColorIcon/MaltaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1322",
+            "component": "MarshallIslandsColorIcon",
+            "source": "src/components/symbol-icons/MarshallIslandsColorIcon/MarshallIslandsColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1397",
+            "component": "MauritaniaColorIcon",
+            "source": "src/components/symbol-icons/MauritaniaColorIcon/MauritaniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1271",
+            "component": "MauritiusColorIcon",
+            "source": "src/components/symbol-icons/MauritiusColorIcon/MauritiusColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=8605-78",
+            "component": "MediumIcon",
+            "source": "src/components/symbol-icons/MediumIcon/MediumIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1400",
+            "component": "MexicoColorIcon",
+            "source": "src/components/symbol-icons/MexicoColorIcon/MexicoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1356",
+            "component": "MicronesiaColorIcon",
+            "source": "src/components/symbol-icons/MicronesiaColorIcon/MicronesiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1350",
+            "component": "MoldovaColorIcon",
+            "source": "src/components/symbol-icons/MoldovaColorIcon/MoldovaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1391",
+            "component": "MonacoColorIcon",
+            "source": "src/components/symbol-icons/MonacoColorIcon/MonacoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1381",
+            "component": "MongoliaColorIcon",
+            "source": "src/components/symbol-icons/MongoliaColorIcon/MongoliaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1314",
+            "component": "MontenegroColorIcon",
+            "source": "src/components/symbol-icons/MontenegroColorIcon/MontenegroColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1282",
+            "component": "MoroccoColorIcon",
+            "source": "src/components/symbol-icons/MoroccoColorIcon/MoroccoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1409",
+            "component": "MozambiqueColorIcon",
+            "source": "src/components/symbol-icons/MozambiqueColorIcon/MozambiqueColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1368",
+            "component": "MyanmarColorIcon",
+            "source": "src/components/symbol-icons/MyanmarColorIcon/MyanmarColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7730-478",
+            "component": "MysqlColorIcon",
+            "source": "src/components/symbol-icons/MysqlColorIcon/MysqlColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7730-479",
+            "component": "MysqlIcon",
+            "source": "src/components/symbol-icons/MysqlIcon/MysqlIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1270",
+            "component": "NamibiaColorIcon",
+            "source": "src/components/symbol-icons/NamibiaColorIcon/NamibiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1392",
+            "component": "NauruColorIcon",
+            "source": "src/components/symbol-icons/NauruColorIcon/NauruColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1404-1036",
+            "component": "NaverblogColorIcon",
+            "source": "src/components/symbol-icons/NaverblogColorIcon/NaverblogColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1404-1023",
+            "component": "NaverblogIcon",
+            "source": "src/components/symbol-icons/NaverblogIcon/NaverblogIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1015",
+            "component": "NaverIcon",
+            "source": "src/components/symbol-icons/NaverIcon/NaverIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1327",
+            "component": "NepalColorIcon",
+            "source": "src/components/symbol-icons/NepalColorIcon/NepalColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1286",
+            "component": "NetherlandsColorIcon",
+            "source": "src/components/symbol-icons/NetherlandsColorIcon/NetherlandsColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1334",
+            "component": "NewZealandColorIcon",
+            "source": "src/components/symbol-icons/NewZealandColorIcon/NewZealandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1380",
+            "component": "NicaraguaColorIcon",
+            "source": "src/components/symbol-icons/NicaraguaColorIcon/NicaraguaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1371",
+            "component": "NigerColorIcon",
+            "source": "src/components/symbol-icons/NigerColorIcon/NigerColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1428",
+            "component": "NigeriaColorIcon",
+            "source": "src/components/symbol-icons/NigeriaColorIcon/NigeriaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1329",
+            "component": "NiueColorIcon",
+            "source": "src/components/symbol-icons/NiueColorIcon/NiueColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1287",
+            "component": "NorthMacedoniaColorIcon",
+            "source": "src/components/symbol-icons/NorthMacedoniaColorIcon/NorthMacedoniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1305",
+            "component": "NorwayColorIcon",
+            "source": "src/components/symbol-icons/NorwayColorIcon/NorwayColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-74",
+            "component": "NotionIcon",
+            "source": "src/components/symbol-icons/NotionIcon/NotionIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1339",
+            "component": "OmanColorIcon",
+            "source": "src/components/symbol-icons/OmanColorIcon/OmanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2956",
+            "component": "OperaColorIcon",
+            "source": "src/components/symbol-icons/OperaColorIcon/OperaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1398",
+            "component": "PakistanColorIcon",
+            "source": "src/components/symbol-icons/PakistanColorIcon/PakistanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1324",
+            "component": "PalauColorIcon",
+            "source": "src/components/symbol-icons/PalauColorIcon/PalauColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1436",
+            "component": "PanamaColorIcon",
+            "source": "src/components/symbol-icons/PanamaColorIcon/PanamaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1325",
+            "component": "PapuaNewGuineaColorIcon",
+            "source": "src/components/symbol-icons/PapuaNewGuineaColorIcon/PapuaNewGuineaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1376",
+            "component": "ParaguayColorIcon",
+            "source": "src/components/symbol-icons/ParaguayColorIcon/ParaguayColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1772-1059",
+            "component": "PaycoIcon",
+            "source": "src/components/symbol-icons/PaycoIcon/PaycoIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4394-90",
+            "component": "PaypalColorIcon",
+            "source": "src/components/symbol-icons/PaypalColorIcon/PaypalColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1425",
+            "component": "PeruColorIcon",
+            "source": "src/components/symbol-icons/PeruColorIcon/PeruColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1404",
+            "component": "PhilippinesColorIcon",
+            "source": "src/components/symbol-icons/PhilippinesColorIcon/PhilippinesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1353",
+            "component": "PolandColorIcon",
+            "source": "src/components/symbol-icons/PolandColorIcon/PolandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1311",
+            "component": "PortugalColorIcon",
+            "source": "src/components/symbol-icons/PortugalColorIcon/PortugalColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2957",
+            "component": "ProductHuntColorIcon",
+            "source": "src/components/symbol-icons/ProductHuntColorIcon/ProductHuntColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1336",
+            "component": "QatarColorIcon",
+            "source": "src/components/symbol-icons/QatarColorIcon/QatarColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1258",
+            "component": "RepublicOfTheCongoColorIcon",
+            "source": "src/components/symbol-icons/RepublicOfTheCongoColorIcon/RepublicOfTheCongoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1355",
+            "component": "RomaniaColorIcon",
+            "source": "src/components/symbol-icons/RomaniaColorIcon/RomaniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2953",
+            "component": "RstudioColorIcon",
+            "source": "src/components/symbol-icons/RstudioColorIcon/RstudioColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1351",
+            "component": "RussiaColorIcon",
+            "source": "src/components/symbol-icons/RussiaColorIcon/RussiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1279",
+            "component": "RwandaColorIcon",
+            "source": "src/components/symbol-icons/RwandaColorIcon/RwandaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1416",
+            "component": "SaintKittsAndNevisColorIcon",
+            "source": "src/components/symbol-icons/SaintKittsAndNevisColorIcon/SaintKittsAndNevisColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1445",
+            "component": "SaintLuciaColorIcon",
+            "source": "src/components/symbol-icons/SaintLuciaColorIcon/SaintLuciaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1422",
+            "component": "SaintVincentAndTheGrenadinesColorIcon",
+            "source": "src/components/symbol-icons/SaintVincentAndTheGrenadinesColorIcon/SaintVincentAndTheGrenadinesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1383",
+            "component": "SamoaColorIcon",
+            "source": "src/components/symbol-icons/SamoaColorIcon/SamoaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1294",
+            "component": "SanMarinoColorIcon",
+            "source": "src/components/symbol-icons/SanMarinoColorIcon/SanMarinoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1291",
+            "component": "SaoTomeAndPrincipeColorIcon",
+            "source": "src/components/symbol-icons/SaoTomeAndPrincipeColorIcon/SaoTomeAndPrincipeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1342",
+            "component": "SaudiArabiaColorIcon",
+            "source": "src/components/symbol-icons/SaudiArabiaColorIcon/SaudiArabiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1260",
+            "component": "SenegalColorIcon",
+            "source": "src/components/symbol-icons/SenegalColorIcon/SenegalColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-99",
+            "component": "SentryIcon",
+            "source": "src/components/symbol-icons/SentryIcon/SentryIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1343",
+            "component": "SerbiaColorIcon",
+            "source": "src/components/symbol-icons/SerbiaColorIcon/SerbiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1262",
+            "component": "SeychellesColorIcon",
+            "source": "src/components/symbol-icons/SeychellesColorIcon/SeychellesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1256",
+            "component": "SierraLeoneColorIcon",
+            "source": "src/components/symbol-icons/SierraLeoneColorIcon/SierraLeoneColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1377",
+            "component": "SingaporeColorIcon",
+            "source": "src/components/symbol-icons/SingaporeColorIcon/SingaporeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1016",
+            "component": "SlackColorIcon",
+            "source": "src/components/symbol-icons/SlackColorIcon/SlackColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1402-1012",
+            "component": "SlackIcon",
+            "source": "src/components/symbol-icons/SlackIcon/SlackIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1296",
+            "component": "SlovakiaColorIcon",
+            "source": "src/components/symbol-icons/SlovakiaColorIcon/SlovakiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1297",
+            "component": "SloveniaColorIcon",
+            "source": "src/components/symbol-icons/SloveniaColorIcon/SloveniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1369",
+            "component": "SolomonIslandsColorIcon",
+            "source": "src/components/symbol-icons/SolomonIslandsColorIcon/SolomonIslandsColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1273",
+            "component": "SomaliaColorIcon",
+            "source": "src/components/symbol-icons/SomaliaColorIcon/SomaliaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1274",
+            "component": "SouthAfricaColorIcon",
+            "source": "src/components/symbol-icons/SouthAfricaColorIcon/SouthAfricaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1401",
+            "component": "SouthKoreaColorIcon",
+            "source": "src/components/symbol-icons/SouthKoreaColorIcon/SouthKoreaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1272",
+            "component": "SouthSudanColorIcon",
+            "source": "src/components/symbol-icons/SouthSudanColorIcon/SouthSudanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1372",
+            "component": "SpainColorIcon",
+            "source": "src/components/symbol-icons/SpainColorIcon/SpainColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1374",
+            "component": "SriLankaColorIcon",
+            "source": "src/components/symbol-icons/SriLankaColorIcon/SriLankaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4649-78",
+            "component": "StorybookColorIcon",
+            "source": "src/components/symbol-icons/StorybookColorIcon/StorybookColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4649-77",
+            "component": "StorybookIcon",
+            "source": "src/components/symbol-icons/StorybookIcon/StorybookIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4394-229",
+            "component": "StripeColorIcon",
+            "source": "src/components/symbol-icons/StripeColorIcon/StripeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=4394-238",
+            "component": "StripeIcon",
+            "source": "src/components/symbol-icons/StripeIcon/StripeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1359",
+            "component": "SudanColorIcon",
+            "source": "src/components/symbol-icons/SudanColorIcon/SudanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1420",
+            "component": "SurinameColorIcon",
+            "source": "src/components/symbol-icons/SurinameColorIcon/SurinameColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1403",
+            "component": "SwedenColorIcon",
+            "source": "src/components/symbol-icons/SwedenColorIcon/SwedenColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1295",
+            "component": "SwitzerlandColorIcon",
+            "source": "src/components/symbol-icons/SwitzerlandColorIcon/SwitzerlandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1441",
+            "component": "SyriaColorIcon",
+            "source": "src/components/symbol-icons/SyriaColorIcon/SyriaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1551-977",
+            "component": "TaegukColorIcon",
+            "source": "src/components/symbol-icons/TaegukColorIcon/TaegukColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1551-973",
+            "component": "TaegukIcon",
+            "source": "src/components/symbol-icons/TaegukIcon/TaegukIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1361",
+            "component": "TajikistanColorIcon",
+            "source": "src/components/symbol-icons/TajikistanColorIcon/TajikistanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1265",
+            "component": "TanzaniaColorIcon",
+            "source": "src/components/symbol-icons/TanzaniaColorIcon/TanzaniaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1328",
+            "component": "ThailandColorIcon",
+            "source": "src/components/symbol-icons/ThailandColorIcon/ThailandColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1408",
+            "component": "TogoColorIcon",
+            "source": "src/components/symbol-icons/TogoColorIcon/TogoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1331",
+            "component": "TongaColorIcon",
+            "source": "src/components/symbol-icons/TongaColorIcon/TongaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7007-77",
+            "component": "TrelloIcon",
+            "source": "src/components/symbol-icons/TrelloIcon/TrelloIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1406",
+            "component": "TrinidadAndTobagoColorIcon",
+            "source": "src/components/symbol-icons/TrinidadAndTobagoColorIcon/TrinidadAndTobagoColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1340",
+            "component": "TunisiaColorIcon",
+            "source": "src/components/symbol-icons/TunisiaColorIcon/TunisiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1362",
+            "component": "TurkeyColorIcon",
+            "source": "src/components/symbol-icons/TurkeyColorIcon/TurkeyColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1358",
+            "component": "TurkmenistanColorIcon",
+            "source": "src/components/symbol-icons/TurkmenistanColorIcon/TurkmenistanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1438",
+            "component": "TuvaluColorIcon",
+            "source": "src/components/symbol-icons/TuvaluColorIcon/TuvaluColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1306",
+            "component": "UgandaColorIcon",
+            "source": "src/components/symbol-icons/UgandaColorIcon/UgandaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1352",
+            "component": "UkraineColorIcon",
+            "source": "src/components/symbol-icons/UkraineColorIcon/UkraineColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1394",
+            "component": "UnitedArabEmiratesColorIcon",
+            "source": "src/components/symbol-icons/UnitedArabEmiratesColorIcon/UnitedArabEmiratesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1337",
+            "component": "UnitedKingdomColorIcon",
+            "source": "src/components/symbol-icons/UnitedKingdomColorIcon/UnitedKingdomColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1399",
+            "component": "UnitedStatesColorIcon",
+            "source": "src/components/symbol-icons/UnitedStatesColorIcon/UnitedStatesColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1434",
+            "component": "UruguayColorIcon",
+            "source": "src/components/symbol-icons/UruguayColorIcon/UruguayColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1437",
+            "component": "UzbekistanColorIcon",
+            "source": "src/components/symbol-icons/UzbekistanColorIcon/UzbekistanColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1320",
+            "component": "VanuatuColorIcon",
+            "source": "src/components/symbol-icons/VanuatuColorIcon/VanuatuColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1435",
+            "component": "VaticanCityColorIcon",
+            "source": "src/components/symbol-icons/VaticanCityColorIcon/VaticanCityColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1430",
+            "component": "VenezuelaColorIcon",
+            "source": "src/components/symbol-icons/VenezuelaColorIcon/VenezuelaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1388",
+            "component": "VietnamColorIcon",
+            "source": "src/components/symbol-icons/VietnamColorIcon/VietnamColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=1346-2958",
+            "component": "VscodeColorIcon",
+            "source": "src/components/symbol-icons/VscodeColorIcon/VscodeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7730-475",
+            "component": "VscodeIcon",
+            "source": "src/components/symbol-icons/VscodeIcon/VscodeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=6959-77",
+            "component": "XIcon",
+            "source": "src/components/symbol-icons/XIcon/XIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1348",
+            "component": "YemenColorIcon",
+            "source": "src/components/symbol-icons/YemenColorIcon/YemenColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7301-800",
+            "component": "YoutubeColorIcon",
+            "source": "src/components/symbol-icons/YoutubeColorIcon/YoutubeColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=7301-806",
+            "component": "YoutubeIcon",
+            "source": "src/components/symbol-icons/YoutubeIcon/YoutubeIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1261",
+            "component": "ZambiaColorIcon",
+            "source": "src/components/symbol-icons/ZambiaColorIcon/ZambiaColorIcon.tsx"
+        },
+        {
+            "url": "https://www.figma.com/design/DVgbt41m23pnHjAL8ZYsD3?node-id=9214-1255",
+            "component": "ZimbabweColorIcon",
+            "source": "src/components/symbol-icons/ZimbabweColorIcon/ZimbabweColorIcon.tsx"
+        }
+    ]
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -4,7 +4,8 @@
         "baseUrl": ".",
         "paths": {
             "~/*": ["./src/*"]
-        }
+        },
+        "types": ["@figma/code-connect/figma-types"]
     },
     "include": ["."]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,13 +440,13 @@ importers:
         version: 9.39.5(jiti@2.7.0)
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+        version: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
       ts-jest:
         specifier: ^29.4.12
-        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.2)(jest-util@30.4.1)(jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
@@ -861,6 +861,9 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
     devDependencies:
+      '@figma/code-connect':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -12464,7 +12467,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))':
+  '@jest/core@30.4.2(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -12480,7 +12483,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.20.1)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@22.20.1)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -14686,9 +14689,9 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/debug@4.1.12)(@types/node@20.19.43)(@vitest/browser@3.2.7)(happy-dom@20.11.2)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.33.0)(sass@1.102.0)(tsx@4.23.13)(yaml@2.9.0)
+      vitest: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.21)(@vitest/browser@3.2.7)(happy-dom@20.9.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.33.0)(sass@1.102.0)(tsx@4.23.13)(yaml@2.9.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.7(playwright@1.62.1)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(sass@1.102.0)(tsx@4.23.13)(yaml@2.9.0))(vitest@3.2.7)
+      '@vitest/browser': 3.2.7(playwright@1.62.1)(vite@8.2.1(@types/node@22.19.21)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.13)(yaml@2.9.0))(vitest@3.2.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -15866,10 +15869,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-register@3.6.0(esbuild@0.28.2):
+  esbuild-register@3.6.0(esbuild@0.27.7):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.28.2
+      esbuild: 0.27.7
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -15979,7 +15982,7 @@ snapshots:
       '@typescript-eslint/parser': 8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
@@ -16012,7 +16015,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -16035,7 +16038,7 @@ snapshots:
       '@typescript-eslint/parser': 8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -17233,15 +17236,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest-cli@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -17252,7 +17255,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest-config@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -17279,13 +17282,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.43
-      esbuild-register: 3.6.0(esbuild@0.28.2)
+      esbuild-register: 3.6.0(esbuild@0.27.7)
       ts-node: 10.9.2(@types/node@20.19.43)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.4.2(@types/node@22.20.1)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest-config@30.4.2(@types/node@22.20.1)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -17312,7 +17315,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.20.1
-      esbuild-register: 3.6.0(esbuild@0.28.2)
+      esbuild-register: 3.6.0(esbuild@0.27.7)
       ts-node: 10.9.2(@types/node@20.19.43)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -17571,12 +17574,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-cli: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19994,12 +19997,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.2)(jest-util@30.4.1)(jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.28.2))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest: 30.4.2(@types/node@20.19.43)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -20012,7 +20015,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.0)
-      esbuild: 0.28.2
+      esbuild: 0.27.7
       jest-util: 30.4.1
 
   ts-morph@22.0.0:

--- a/scripts/icon-extractor/package.json
+++ b/scripts/icon-extractor/package.json
@@ -5,6 +5,7 @@
     "description": "Internal tool that extracts icons from Figma and generates @vapor-ui/icons components",
     "type": "module",
     "scripts": {
+        "code-connect": "tsx --env-file-if-exists=.env ./src/code-connect.ts",
         "extract": "tsx --env-file-if-exists=.env ./src/cli.ts",
         "format": "prettier --write \"./{src,tests}/**/*.{ts,md}\"",
         "format:check": "prettier --check \"./{src,tests}/**/*.{ts,md}\"",

--- a/scripts/icon-extractor/src/cli.ts
+++ b/scripts/icon-extractor/src/cli.ts
@@ -14,6 +14,7 @@ import pLimit from 'p-limit';
 
 import { ICON_TYPE_NAMES, colorFrameIds, figma, iconTypes, isIconType } from '~/config';
 import { downloadSvg, fetchIconNodes, resolveSvgUrls } from '~/downloader/svg-downloader';
+import { writeCodeConnectBatch } from '~/generator/code-connect-generator';
 import type { WriteResult } from '~/generator/component-generator';
 import { removeStaleIcons, writeIcon, writeIconsIndex } from '~/generator/component-generator';
 import { writeSyncSummary } from '~/summary/sync-summary';
@@ -81,6 +82,10 @@ const deleted = await removeStaleIcons(targetDir, iconNames);
 for (const name of deleted) log.warn(`🗑️  Deleted: ${name}`);
 
 await writeIconsIndex(targetDir, iconNames);
+
+// Same node list the components came from, so the Code Connect node ids cannot drift.
+log.info(`Code Connect mapping written to ${await writeCodeConnectBatch(type, iconType, nodes)}`);
+
 log.info(`Sync complete for ${type} icons`);
 
 // Handed to `write-release-notes` as a file: each icon type syncs in its own process.

--- a/scripts/icon-extractor/src/code-connect.ts
+++ b/scripts/icon-extractor/src/code-connect.ts
@@ -1,0 +1,39 @@
+/**
+ * Regenerate the Figma Code Connect mapping for `@vapor-ui/icons`.
+ *
+ * `cli.ts` already writes this mapping on every sync — use this entry when you only want to
+ * refresh the node ids, without re-downloading and re-generating all 800+ components.
+ *
+ * Usage:
+ *   tsx --env-file=.env ./src/code-connect.ts
+ *
+ * Requires FIGMA_TOKEN.
+ */
+import process from 'node:process';
+
+import { ICON_TYPE_NAMES, figma, iconTypes } from '~/config';
+import { fetchIconNodes } from '~/downloader/svg-downloader';
+import { writeCodeConnectBatch } from '~/generator/code-connect-generator';
+import { log } from '~/utils/logger';
+
+if (!process.env.FIGMA_TOKEN) {
+    log.error('FIGMA_TOKEN environment variable is not set.');
+    process.exit(1);
+}
+
+for (const type of ICON_TYPE_NAMES) {
+    const iconType = iconTypes[type];
+    const nodes = await fetchIconNodes({
+        fileKey: figma.fileKey,
+        frameIds: iconType.frames.map((frame) => frame.id),
+    });
+
+    // Writing an empty mapping would unpublish every icon on the next publish.
+    if (nodes.length === 0) {
+        log.error(`No ${type} icons found! Check FIGMA_TOKEN and API access.`);
+        process.exit(1);
+    }
+
+    const outFile = await writeCodeConnectBatch(type, iconType, nodes);
+    log.info(`${nodes.length} ${type} icons → ${outFile}`);
+}

--- a/scripts/icon-extractor/src/generator/code-connect-generator.ts
+++ b/scripts/icon-extractor/src/generator/code-connect-generator.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import prettier from 'prettier';
+
+import type { IconNode } from '~/api/types';
+import type { IconType, IconTypeConfig } from '~/config';
+import { figma } from '~/config';
+import { REPO_ROOT } from '~/utils/file-system';
+import { normalizeIconName } from '~/utils/icon-name';
+
+/** Every icon shares one template; the batch file only carries the per-icon data. */
+const TEMPLATE_FILE = './icon.figma.batch.ts';
+const PACKAGE_DIR = 'packages/icons';
+const FIGMA_DESIGN_URL = 'https://www.figma.com/design';
+
+/** One entry of a `.figma.batch.json` file. */
+type BatchEntry = { url: string; component: string; source: string };
+
+const toBatchEntry = (node: IconNode, targetPath: string): BatchEntry => {
+    const component = normalizeIconName(node.name);
+
+    return {
+        url: `${FIGMA_DESIGN_URL}/${figma.fileKey}?node-id=${node.id.replace(':', '-')}`,
+        component,
+        // Package-relative, matching @vapor-ui/composites' Code Connect files.
+        source: `${path.relative(PACKAGE_DIR, targetPath)}/${component}/${component}.tsx`,
+    };
+};
+
+/**
+ * Write `packages/icons/src/icons-<type>.figma.batch.json` — the Code Connect mapping between
+ * the Figma icon components and their React counterparts.
+ *
+ * Written from the same node list the components are generated from, so the Figma node ids can
+ * never drift from what got synced. Publish with `pnpm --filter @vapor-ui/icons figma:publish`.
+ */
+const writeCodeConnectBatch = async (
+    type: IconType,
+    { targetPath }: IconTypeConfig,
+    nodes: IconNode[],
+): Promise<string> => {
+    const entries = nodes
+        .map((node) => toBatchEntry(node, targetPath))
+        .sort((a, b) => a.component.localeCompare(b.component));
+
+    // Two Figma nodes normalizing to one component name would silently map the same snippet
+    // twice — and the component generator would have written one folder for both.
+    const names = entries.map(({ component }) => component);
+    const duplicates = names.filter((name, index) => names.indexOf(name) !== index);
+    if (duplicates.length > 0) {
+        throw new Error(
+            `Duplicate icon component names in the Figma "${type}" frames: ${duplicates.join(', ')}`,
+        );
+    }
+
+    const outFile = path.join(REPO_ROOT, PACKAGE_DIR, 'src', `icons-${type}.figma.batch.json`);
+    const json = JSON.stringify({ templateFile: TEMPLATE_FILE, components: entries });
+    await fs.writeFile(
+        outFile,
+        await prettier.format(json, {
+            ...(await prettier.resolveConfig(outFile)),
+            filepath: outFile,
+        }),
+    );
+
+    return outFile;
+};
+
+export type { BatchEntry };
+export { writeCodeConnectBatch };


### PR DESCRIPTION
## Related Issues

Base: #734 — 아이콘 추출 흐름이 그 PR에서 재구조화돼서, main 기준으로 짜면 충돌합니다.

## Description of Changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Vapor UI 아이콘이 Figma Code Connect와 연동됩니다.
  * Figma에서 아이콘 컴포넌트와 실제 `@vapor-ui/icons` 사용 예시를 연결해 확인할 수 있습니다.
  * 국가별 색상 아이콘과 주요 브랜드 아이콘을 포함한 대규모 아이콘 매핑을 제공합니다.

* **개선 사항**
  * 아이콘 동기화 과정에서 Figma 연결 정보가 자동으로 생성 및 갱신됩니다.
  * 중복되거나 누락된 아이콘 매핑을 감지해 안정적인 연동을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

`@vapor-ui/icons`의 아이콘 814개는 Figma 컴포넌트와 이름으로만 이어져 있었습니다. Dev Mode에서 아이콘을 눌러도 어떤 컴포넌트를 import해야 하는지 나오지 않습니다. Code Connect로 그 연결을 채웁니다.

### batch 표기법

`@figma/code-connect@2.0.0`은 `.figma.batch.json` 하나에 컴포넌트를 나열하고, 공유 템플릿이 `figma.batch`로 항목별 데이터를 받습니다. 아이콘마다 파일을 둘 필요가 없으니 매핑 814개가 파일 3개로 끝납니다.

아이콘은 variant가 없는 개별 COMPONENT입니다. prop으로 매핑할 축이 없고 스니펫도 `<XxxIcon />` 하나뿐이라, 파일을 814개로 쪼개면 전부 같은 내용의 복사본이 됩니다.

구 React parser 방식인 `*.figma.tsx`는 2026-08-17 기준 폐기 예정 표기라 쓰지 않았습니다. 현행은 `figma.code` 템플릿이고, `@vapor-ui/composites`가 이미 그 방식입니다.

| 파일 | 역할 |
| --- | --- |
| `packages/icons/figma.config.json` | fileKey · label · include(`src/**/*.figma.batch.json`) |
| `packages/icons/src/icon.figma.batch.ts` | 814개가 공유하는 템플릿 |
| `packages/icons/src/icons-{basic,symbol}.figma.batch.json` | 생성물 (basic 556 · symbol 258) |
| `scripts/icon-extractor/src/generator/code-connect-generator.ts` | 생성기 |
| `scripts/icon-extractor/src/code-connect.ts` | SVG 재다운로드 없이 노드 ID만 갱신하는 엔트리 |

### 노드 ID가 어긋나지 않게

`cli.ts`가 컴포넌트를 생성한 바로 그 노드 목록으로 배치 파일도 씁니다. 중간에 낀 단계가 없으니 어긋날 여지도 없습니다. 출력이 `packages/icons/src/` 안이라 sync 워크플로의 `git add packages/icons/src/`에 이미 걸립니다 — 워크플로는 건드리지 않았습니다.

두 노드가 같은 컴포넌트 이름으로 정규화되면 생성기가 throw합니다. 그 경우엔 컴포넌트 폴더도 하나로 합쳐져 있었을 테니, 조용히 지나갈 일이 아닙니다.

### 발행

```
pnpm --filter @vapor-ui/icons figma:check     # dry-run
pnpm --filter @vapor-ui/icons figma:publish   # 실제 발행
```

**814개는 이미 발행했습니다.**

발행 중에 `AiSmartieIcon` 하나가 Figma UI에서 손으로 만든 매핑에 막혔습니다. 그 매핑이 가리키던 `packages/ui/src/icons/AiChatFillIcon/AiChatFillIcon.tsx`는 이 저장소에 없는 패키지의 없는 컴포넌트입니다. 템플릿도 없어서 스니펫을 못 내던 껍데기라 `--force`로 덮었습니다.

### 일부러 좁힌 범위

인스턴스 리사이즈 → `size` prop 매핑은 넣지 않았습니다. Figma 아이콘 컴포넌트가 16×16 고정이고 프로퍼티가 0개라 읽을 축 자체가 없습니다.

## Screenshots

코드 쪽 UI 변경은 없습니다. Figma Dev Mode에서 아이콘을 선택했을 때 나오는 결과입니다.

`StarIcon` (`2:1887`) — 확장 전에 이 하나만 먼저 발행해 대조했습니다.

```json
{
  "componentName": "StarIcon",
  "source": "src/components/basic-icons/StarIcon/StarIcon.tsx",
  "label": "React",
  "hasTemplate": true,
  "snippet": "<StarIcon />",
  "snippetImports": ["import { StarIcon } from '@vapor-ui/icons';"]
}
```

`AiSmartieIcon` (`7102:2103`) — 손으로 만든 매핑을 덮기 전후.

```diff
- "source": "packages/ui/src/icons/AiChatFillIcon/AiChatFillIcon.tsx", "hasTemplate": false
+ "source": "src/components/basic-icons/AiSmartieIcon/AiSmartieIcon.tsx", "hasTemplate": true, "snippet": "<AiSmartieIcon />"
```

## Checklist

- [x] The PR title follows the Conventional Commits convention. (e.g., feat, fix, docs, style, refactor, test, chore)
- [ ] I have added tests for my changes. — 유닛 테스트는 없습니다. 대신 `figma connect publish --dry-run`이 814개 전부 valid(exit 0)로 통과하고, 생성물과 로컬 컴포넌트 디렉터리가 1:1(차집합 0)이며 `source` 경로가 전부 실재하는 것을 확인했습니다.
- [x] I have updated the Storybook or relevant documentation. — 발행·재생성 방법은 `icon.figma.batch.ts`와 `code-connect-generator.ts` 주석, 그리고 두 패키지의 npm script에 있습니다.
- [ ] I have added a changeset for this change. — dist에 들어가는 게 없습니다. tsup 엔트리는 `src/index.ts` 하나고 배치 파일은 거기서 도달하지 않습니다. 발행되는 패키지 내용물이 그대로라 버전을 올릴 이유가 없습니다.
- [x] I have performed a self-code review.
- [x] I have followed the project's [coding conventions](https://github.com/goorm-dev/vapor-ui/blob/main/.gemini/styleguide.md) and component patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
